### PR TITLE
Implement Stock Trading App design as a new /trading route

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
               }
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "src/styles/acme-tokens.css"
             ],
             "scripts": []
           },
@@ -89,7 +90,8 @@
               }
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "src/styles/acme-tokens.css"
             ],
             "scripts": []
           }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-stock />
+<router-outlet />

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { StockComponent } from './stock/stock.component';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  imports: [StockComponent],
+  imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,8 @@
 import { Routes } from '@angular/router';
+import { StockComponent } from './stock/stock.component';
+import { TradingAppComponent } from './trading-app/trading-app.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: StockComponent },
+  { path: 'trading', component: TradingAppComponent }
+];

--- a/src/app/trading-app/trading-app.component.css
+++ b/src/app/trading-app/trading-app.component.css
@@ -1,0 +1,288 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: var(--acme-color-canvas);
+  color: var(--acme-color-text);
+  font-family: var(--acme-font-sans);
+}
+
+a { color: var(--acme-color-link); text-decoration: none; }
+a:hover { color: var(--acme-color-primary-hover); }
+input, select { font-family: var(--acme-font-sans); }
+
+.app { min-height: 100vh; }
+
+/* ---- Topbar ---- */
+.topbar-wrap { position: sticky; top: 0; z-index: 20; padding: 16px 24px 0; }
+.topbar {
+  display: flex; align-items: center; gap: 6px;
+  padding: 8px 10px 8px 18px;
+  border-radius: 999px;
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-md);
+  max-width: 1280px; margin: 0 auto;
+}
+.wordmark {
+  font: 800 16px var(--acme-font-display); letter-spacing: 0.1em; color: var(--acme-color-text);
+  display: flex; align-items: center; gap: 8px;
+}
+.wordmark__mark {
+  background: var(--acme-red-600); color: #fff; font-style: italic; font-weight: 800;
+  width: 22px; height: 22px; border-radius: 6px; display: inline-grid; place-items: center; font-size: 13px;
+}
+.nav { display: flex; gap: 4px; margin-left: 28px; }
+.nav__link {
+  font: 600 13px var(--acme-font-sans); padding: 8px 16px; border-radius: 999px; color: var(--acme-color-text-muted);
+}
+.nav__link:hover { background: var(--acme-material-glass); color: var(--acme-color-text); }
+.nav__link--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); color: var(--acme-color-text); }
+.nav__link--active:hover { background: var(--acme-color-surface-raised); }
+
+.icon-btn {
+  margin-left: auto; width: 36px; height: 36px; border-radius: 999px; border: none;
+  background: var(--acme-material-glass); display: grid; place-items: center; color: var(--acme-color-text); cursor: pointer;
+}
+.icon-btn:hover { background: var(--acme-material-glass-strong); }
+
+/* ---- Layout ---- */
+.main { max-width: 1280px; margin: 0 auto; padding: 24px 24px 80px; }
+.dashboard-grid { display: grid; grid-template-columns: 1fr 360px; gap: 24px; align-items: start; }
+.dashboard-col { display: grid; gap: 24px; }
+.stack { display: grid; gap: 24px; }
+
+.card {
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-sm);
+  border-radius: 20px;
+  padding: 24px;
+}
+.card__title { font: 700 16px var(--acme-font-display); margin: 0 0 14px; }
+
+/* ---- Stock head ---- */
+.stock-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
+.stock-head__id { display: grid; gap: 6px; }
+.stock-head__symbol-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.stock-head__symbol { font: 700 30px var(--acme-font-display); margin: 0; }
+.stock-head__name { font: 14px var(--acme-font-sans); color: var(--acme-color-text-muted); }
+.stock-head__price-block { text-align: right; }
+.stock-head__price { font: 700 32px var(--acme-font-display); font-variant-numeric: tabular-nums; }
+
+.badge {
+  font: 600 11px var(--acme-font-sans); padding: 3px 10px; border-radius: 999px;
+  background: var(--acme-color-surface); color: var(--acme-color-text-muted);
+}
+.badge--info { background: var(--acme-color-info-soft); color: var(--acme-color-info-soft-text); }
+.badge--success { background: var(--acme-color-success-soft); color: var(--acme-color-success-soft-text); }
+.badge--muted { background: var(--acme-color-surface); color: var(--acme-color-text-muted); }
+
+.pill-btn {
+  display: flex; align-items: center; gap: 6px; height: 28px; padding: 0 12px; border-radius: 999px;
+  border: none; cursor: pointer; font: 600 12px var(--acme-font-sans);
+}
+.pill-btn--warning { background: var(--acme-color-warning-soft); color: var(--acme-color-warning-soft-text); }
+.pill-btn--ghost { background: var(--acme-material-glass); color: var(--acme-color-text-muted); }
+.pill-btn--ghost:hover { color: var(--acme-color-text); }
+
+.change { display: inline-flex; align-items: center; gap: 6px; font: 600 14px var(--acme-font-sans); }
+.change--up { color: var(--acme-color-success); }
+.change--down { color: var(--acme-color-danger); }
+
+/* ---- Range group ---- */
+.range-group {
+  display: inline-flex; gap: 2px; padding: 3px; border-radius: 999px; background: var(--acme-color-surface);
+  margin: 18px 0 4px;
+}
+.range-btn { height: 30px; padding: 0 14px; border-radius: 999px; border: none; background: transparent; font: 600 12px var(--acme-font-sans); color: var(--acme-color-text-muted); cursor: pointer; }
+.range-btn--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); color: var(--acme-color-text); }
+
+/* ---- Chart ---- */
+.chart-wrap { margin: 8px 0 16px; }
+.chart-svg { width: 100%; height: 220px; display: block; }
+.grid-line { stroke: var(--acme-color-border); stroke-width: 1; }
+.chart-line { stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
+.chart-line--up { stroke: var(--acme-color-success); }
+.chart-line--down { stroke: var(--acme-color-danger); }
+
+/* ---- Stats ---- */
+.stats-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px 24px; padding: 20px 0 4px;
+  border-top: 1px solid var(--acme-color-border);
+}
+.stats-grid__label { font: 600 11px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em; color: var(--acme-color-text-muted); margin-bottom: 4px; }
+.stats-grid__value { font: 600 14px var(--acme-font-sans); font-variant-numeric: tabular-nums; }
+
+/* ---- Buttons ---- */
+.trade-actions { display: flex; gap: 12px; margin-top: 12px; }
+.btn {
+  flex: 1; height: 44px; border-radius: 999px; border: none; cursor: pointer;
+  font: 700 14px var(--acme-font-sans);
+}
+.btn:active { scale: 0.97; }
+.btn--success { background: var(--acme-color-success); color: #fff; }
+.btn--success:hover { filter: brightness(0.92); }
+.btn--outline { background: var(--acme-color-surface-raised); color: var(--acme-color-text); border: 1px solid var(--acme-color-border-strong); }
+.btn--outline:hover { background: var(--acme-color-surface); }
+.btn--primary { background: var(--acme-color-primary); color: #fff; flex: none; height: 40px; padding: 0 18px; font-weight: 600; }
+.btn--primary:hover { background: var(--acme-color-primary-hover); }
+.btn--primary:active { scale: 0.97; }
+.btn--secondary {
+  background: var(--acme-material-glass); box-shadow: var(--acme-glass-edge), var(--acme-shadow-sm); flex: none;
+  height: 40px; padding: 0 16px; font: 600 14px var(--acme-font-sans); color: var(--acme-color-text);
+}
+.btn--ghost {
+  background: transparent; border: 1px solid var(--acme-color-border-strong); color: var(--acme-color-text-muted);
+  flex: none; height: 40px; padding: 0 18px; font: 600 14px var(--acme-font-sans);
+}
+.btn--ghost:hover { color: var(--acme-color-text); border-color: var(--acme-color-text-muted); }
+.btn--sm { flex: none; height: 28px; padding: 0 12px; font: 600 12px var(--acme-font-sans); margin-right: 6px; }
+
+/* ---- News ---- */
+.news-item { display: block; padding: 12px 0; border-bottom: 1px solid var(--acme-color-border); color: inherit; }
+.news-item:hover { color: var(--acme-color-link); }
+.news-item__title { font: 600 14px var(--acme-font-sans); margin-bottom: 4px; }
+.news-item__meta { font: 12px var(--acme-font-sans); color: var(--acme-color-text-muted); }
+
+/* ---- Sidebar / search ---- */
+.sidebar { display: grid; gap: 16px; align-content: start; }
+.search-box { display: flex; align-items: center; gap: 8px; padding: 0 4px; }
+.search-box__input {
+  flex: 1; height: 36px; border: none; background: transparent; font: 14px var(--acme-font-sans); color: var(--acme-color-text); outline: none;
+}
+.search-results { display: grid; gap: 2px; }
+.search-result {
+  display: flex; justify-content: space-between; align-items: center; gap: 8px; text-align: left; padding: 10px 12px;
+  border-radius: 12px; border: none; background: transparent; cursor: pointer; font: 14px var(--acme-font-sans); color: var(--acme-color-text);
+}
+.search-result:hover { background: var(--acme-color-surface); }
+.search-result__symbol { font: 700 13px var(--acme-font-mono); }
+.search-result__name {
+  flex: 1; margin-left: 8px; color: var(--acme-color-text-muted); font-size: 13px; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.muted-note { margin: 0; padding: 8px 4px; font-size: 13px; color: var(--acme-color-text-muted); }
+
+.tabs { display: flex; gap: 4px; padding: 4px; background: var(--acme-color-surface); border-radius: 999px; }
+.tab { flex: 1; height: 30px; border-radius: 999px; border: none; background: transparent; font: 600 12px var(--acme-font-sans); color: var(--acme-color-text-muted); cursor: pointer; }
+.tab--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); color: var(--acme-color-text); }
+
+.watchlist { display: grid; gap: 3px; max-height: 520px; overflow: auto; }
+.watch-row {
+  display: grid; gap: 4px; text-align: left; padding: 10px 12px; border-radius: 12px; border: none; cursor: pointer; background: transparent;
+}
+.watch-row:hover { background: var(--acme-color-surface); }
+.watch-row--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); }
+.watch-row--active:hover { background: var(--acme-color-surface-raised); }
+.watch-row__top { display: flex; justify-content: space-between; font: 700 13px var(--acme-font-mono); }
+.watch-row__bottom { display: flex; justify-content: space-between; font: 12px var(--acme-font-sans); }
+.watch-row__name {
+  color: var(--acme-color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px;
+}
+
+.text-up { color: var(--acme-color-success); font-weight: 600; }
+.text-down { color: var(--acme-color-danger); font-weight: 600; }
+.tabular { font-variant-numeric: tabular-nums; }
+
+/* ---- Portfolio ---- */
+.portfolio-head { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 16px; }
+.label-caps { font: 600 12px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em; color: var(--acme-color-text-muted); margin-bottom: 6px; }
+.portfolio-total { font: 700 34px var(--acme-font-display); font-variant-numeric: tabular-nums; }
+.portfolio-day { font: 600 14px var(--acme-font-sans); margin-top: 4px; }
+.portfolio-head__right { text-align: right; }
+.portfolio-gain { font: 700 22px var(--acme-font-display); }
+.alloc-bar { display: flex; height: 12px; border-radius: 999px; overflow: hidden; margin-top: 20px; background: var(--acme-color-surface); }
+.alloc-bar > div { height: 100%; }
+.alloc-legend { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 10px; }
+.alloc-legend__item { display: flex; align-items: center; gap: 6px; font: 12px var(--acme-font-sans); color: var(--acme-color-text-muted); }
+.alloc-legend__item span { width: 8px; height: 8px; border-radius: 2px; display: inline-block; }
+
+/* ---- Tables ---- */
+.table-card { overflow: auto; }
+.table { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 760px; }
+.table th {
+  text-align: left; padding: 8px; font: 600 11px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em;
+  color: var(--acme-color-text-muted); border-bottom: 1px solid var(--acme-color-border);
+}
+.table td { padding: 12px 8px; border-bottom: 1px solid var(--acme-color-border); }
+.table .num { text-align: right; }
+.table .nowrap { white-space: nowrap; }
+.table .mono { font-family: var(--acme-font-mono); }
+.table .strong { font: 700 13px var(--acme-font-mono); }
+.table .muted { color: var(--acme-color-text-muted); }
+.table .capitalize { text-transform: capitalize; }
+.orders-title { font: 700 24px var(--acme-font-display); margin: 0 0 16px; }
+
+/* ---- Account ---- */
+.account-stack { display: grid; gap: 24px; max-width: 640px; }
+.account-profile { display: flex; align-items: center; gap: 16px; }
+.avatar {
+  width: 56px; height: 56px; border-radius: 999px; background: var(--acme-color-surface); display: grid; place-items: center;
+  font: 700 18px var(--acme-font-display); color: var(--acme-color-text);
+}
+.account-name { font: 700 18px var(--acme-font-display); }
+.settings-card { display: grid; gap: 16px; }
+.setting-row { display: flex; justify-content: space-between; align-items: center; }
+.setting-row__label { font: 600 14px var(--acme-font-sans); }
+
+.switch {
+  width: 44px; height: 26px; border-radius: 999px; border: none; padding: 2px; cursor: pointer;
+  background: var(--acme-color-border-strong); display: flex; justify-content: flex-start;
+}
+.switch--on { background: var(--acme-color-primary); justify-content: flex-end; }
+.switch span { width: 22px; height: 22px; border-radius: 999px; background: #fff; display: block; }
+
+/* ---- Modal ---- */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgb(12 14 18 / 0.3); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+  display: grid; place-items: center; z-index: 50;
+}
+.modal {
+  width: 440px; max-width: calc(100vw - 32px);
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border-radius: 28px;
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-lg);
+  padding: 28px;
+}
+.modal-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.modal-title { font: 700 20px var(--acme-font-display); margin: 0; }
+
+.side-toggle { display: flex; gap: 8px; margin-bottom: 16px; }
+.side-btn {
+  flex: 1; height: 38px; border-radius: 999px; border: 1px solid var(--acme-color-border-strong); background: transparent;
+  color: var(--acme-color-text-muted); font: 600 13px var(--acme-font-sans); cursor: pointer;
+}
+.side-btn--buy-active { border: none; background: var(--acme-color-success); color: #fff; }
+.side-btn--sell-active { border: none; background: var(--acme-color-danger); color: #fff; }
+
+.ticket-fields { display: grid; gap: 14px; }
+.field-label { display: block; font: 600 13px var(--acme-font-sans); margin-bottom: 6px; }
+.field-input {
+  width: 100%; height: 40px; border-radius: 8px; border: 1px solid var(--acme-color-border-strong);
+  background: var(--acme-color-surface-raised); padding: 0 12px; font-size: 14px; color: var(--acme-color-text); box-sizing: border-box;
+}
+.est-row {
+  display: flex; justify-content: space-between; padding: 12px 0; border-top: 1px solid var(--acme-color-border);
+  font: 600 14px var(--acme-font-sans);
+}
+.modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px; }
+
+.confirm-rows { display: grid; gap: 10px; font: 14px var(--acme-font-sans); margin-bottom: 16px; }
+.confirm-row { display: flex; justify-content: space-between; }
+.confirm-row--total { padding-top: 10px; border-top: 1px solid var(--acme-color-border); font: 700 15px var(--acme-font-sans); }
+.warning-box {
+  border: 1px solid var(--acme-color-border); border-left: 3px solid var(--acme-color-warning); border-radius: 8px;
+  background: var(--acme-color-warning-soft); padding: 12px 14px; margin-bottom: 20px;
+}
+.warning-box p { margin: 0; font-size: 13px; color: var(--acme-color-warning-soft-text); }
+
+.success-block { display: grid; justify-items: center; gap: 14px; text-align: center; padding: 8px 0 4px; }
+.success-icon { width: 56px; height: 56px; border-radius: 999px; background: var(--acme-color-success-soft); display: grid; place-items: center; }
+.order-id { margin: 0; font: 13px var(--acme-font-mono); color: var(--acme-color-text-subtle); }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-thumb { background: var(--acme-color-border-strong); border-radius: 999px; }

--- a/src/app/trading-app/trading-app.component.html
+++ b/src/app/trading-app/trading-app.component.html
@@ -1,0 +1,358 @@
+<div class="app" [style.min-height.vh]="100">
+
+<div class="topbar-wrap">
+<header class="topbar">
+<a href="#" class="wordmark"><span class="wordmark__mark">A</span>ACME TRADE</a>
+<nav class="nav">
+  @for (n of nav; track n.id) {
+    <a href="#" class="nav__link" [class.nav__link--active]="screen() === n.id" (click)="setScreen(n.id); $event.preventDefault()">{{ n.label }}</a>
+  }
+</nav>
+<button class="icon-btn" (click)="toggleTheme()" aria-label="Toggle theme" title="Toggle theme">
+  @if (theme() === 'dark') {
+    <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+  } @else {
+    <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+  }
+</button>
+</header>
+</div>
+
+<main class="main">
+
+@if (screen() === 'dashboard') {
+<div class="dashboard-grid">
+<div class="dashboard-col">
+<div class="card">
+  <div class="stock-head">
+    <div class="stock-head__id">
+      <div class="stock-head__symbol-row">
+        <h2 class="stock-head__symbol">{{ stock().symbol }}</h2>
+        <span class="badge badge--info">{{ stock().exch }}</span>
+        @if (stock().isWatched) {
+          <button class="pill-btn pill-btn--warning" (click)="toggleWatch(stock().symbol)">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" stroke="currentColor" stroke-width="1"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Watching
+          </button>
+        } @else {
+          <button class="pill-btn pill-btn--ghost" (click)="toggleWatch(stock().symbol)">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>Add to watchlist
+          </button>
+        }
+      </div>
+      <div class="stock-head__name">{{ stock().name }}</div>
+    </div>
+    <div class="stock-head__price-block">
+      <div class="stock-head__price">{{ stock().priceLabel }}</div>
+      @if (stock().isUp) {
+        <div class="change change--up"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 15 12 9 18 15"/></svg>{{ stock().changeLabel }} ({{ stock().changePctLabel }})</div>
+      } @else {
+        <div class="change change--down"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>{{ stock().changeLabel }} ({{ stock().changePctLabel }})</div>
+      }
+    </div>
+  </div>
+
+  <div class="range-group" role="group" aria-label="Chart time range">
+    @for (r of rangesIds; track r) {
+      <button class="range-btn" [class.range-btn--active]="range() === r" (click)="setRange(r)">{{ r }}</button>
+    }
+  </div>
+
+  <div class="chart-wrap">
+    <svg viewBox="0 0 800 220" preserveAspectRatio="none" class="chart-svg">
+      <defs>
+        <linearGradient id="areaUp" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" style="stop-color:var(--acme-color-success);stop-opacity:0.28"/><stop offset="100%" style="stop-color:var(--acme-color-success);stop-opacity:0"/></linearGradient>
+        <linearGradient id="areaDown" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" style="stop-color:var(--acme-color-danger);stop-opacity:0.28"/><stop offset="100%" style="stop-color:var(--acme-color-danger);stop-opacity:0"/></linearGradient>
+      </defs>
+      <g aria-hidden="true"><line x1="0" x2="800" y1="55" y2="55" class="grid-line"/><line x1="0" x2="800" y1="110" y2="110" class="grid-line"/><line x1="0" x2="800" y1="165" y2="165" class="grid-line"/></g>
+      @if (chart().rising) {
+        <path [attr.d]="chart().areaPath" fill="url(#areaUp)"/>
+        <path [attr.d]="chart().path" fill="none" class="chart-line chart-line--up"/>
+      } @else {
+        <path [attr.d]="chart().areaPath" fill="url(#areaDown)"/>
+        <path [attr.d]="chart().path" fill="none" class="chart-line chart-line--down"/>
+      }
+    </svg>
+  </div>
+
+  <div class="stats-grid">
+    @for (s of stats(); track s.label) {
+      <div><div class="stats-grid__label">{{ s.label }}</div><div class="stats-grid__value">{{ s.value }}</div></div>
+    }
+  </div>
+
+  <div class="trade-actions">
+    <button class="btn btn--success" (click)="openTicket(stock().symbol, 'buy')">Buy {{ stock().symbol }}</button>
+    <button class="btn btn--outline" (click)="openTicket(stock().symbol, 'sell')">Sell {{ stock().symbol }}</button>
+  </div>
+</div>
+
+<div class="card">
+  <h3 class="card__title">Latest news</h3>
+  <div>
+    @for (item of news(); track item.title) {
+      <a href="#" class="news-item" (click)="$event.preventDefault()">
+        <div class="news-item__title">{{ item.title }}</div>
+        <div class="news-item__meta">{{ item.publisher }} · {{ item.time }}</div>
+      </a>
+    }
+  </div>
+</div>
+</div>
+
+<aside class="card sidebar">
+  <div class="search-box">
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="var(--acme-color-text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+    <input class="search-box__input" [ngModel]="searchQuery()" (ngModelChange)="onSearchChange($event)" placeholder="Search ticker or company"/>
+  </div>
+
+  @if (searchQuery().trim().length > 0 && searchResults().length > 0) {
+    <div class="search-results">
+      @for (m of searchResults(); track m.symbol) {
+        <button class="search-result" (click)="selectSymbol(m.symbol)"><span class="search-result__symbol">{{ m.symbol }}</span><span class="search-result__name">{{ m.name }}</span></button>
+      }
+    </div>
+  } @else if (searchQuery().trim().length > 0) {
+    <p class="muted-note">No matches for &ldquo;{{ searchQuery() }}&rdquo;.</p>
+  } @else {
+    <div role="tablist" aria-label="Market categories" class="tabs">
+      @for (c of categories; track c.id) {
+        <button role="tab" [attr.aria-selected]="category() === c.id" class="tab" [class.tab--active]="category() === c.id" (click)="setCategory(c.id)">{{ c.label }}</button>
+      }
+    </div>
+
+    <div class="watchlist">
+      @for (w of rows(); track w.symbol) {
+        <button class="watch-row" [class.watch-row--active]="w.isActive" [attr.aria-pressed]="w.isActive" (click)="selectSymbol(w.symbol)">
+          <div class="watch-row__top"><span>{{ w.symbol }}</span><span class="tabular">{{ w.priceLabel }}</span></div>
+          <div class="watch-row__bottom">
+            <span class="watch-row__name">{{ w.name }}</span>
+            @if (w.isUp) {
+              <span class="text-up">{{ w.changeLabel }}</span>
+            } @else {
+              <span class="text-down">{{ w.changeLabel }}</span>
+            }
+          </div>
+        </button>
+      }
+      @if (rows().length === 0) {
+        <p class="muted-note">No symbols yet. Search above and add to your watchlist.</p>
+      }
+    </div>
+  }
+</aside>
+</div>
+}
+
+@if (screen() === 'portfolio') {
+<div class="stack">
+<div class="card">
+  <div class="portfolio-head">
+    <div>
+      <div class="label-caps">Portfolio value</div>
+      <div class="portfolio-total">{{ portfolio().totalLabel }}</div>
+      @if (portfolio().dayUp) {
+        <div class="text-up portfolio-day">{{ portfolio().dayLabel }} today</div>
+      } @else {
+        <div class="text-down portfolio-day">{{ portfolio().dayLabel }} today</div>
+      }
+    </div>
+    <div class="portfolio-head__right">
+      <div class="label-caps">Total gain / loss</div>
+      @if (portfolio().gainUp) {
+        <div class="portfolio-gain text-up">{{ portfolio().gainLabel }}</div>
+      } @else {
+        <div class="portfolio-gain text-down">{{ portfolio().gainLabel }}</div>
+      }
+      <div class="muted-note">{{ portfolio().gainPctLabel }} all time</div>
+    </div>
+  </div>
+  <div class="alloc-bar">
+    @for (a of portfolio().allocation; track a.symbol) {
+      <div [style.width.%]="a.pct" [style.background]="a.color" [attr.title]="a.symbol"></div>
+    }
+  </div>
+  <div class="alloc-legend">
+    @for (a of portfolio().allocation; track a.symbol) {
+      <div class="alloc-legend__item"><span [style.background]="a.color"></span>{{ a.symbol }} {{ a.pctLabel }}</div>
+    }
+  </div>
+</div>
+
+<div class="card table-card">
+  <h3 class="card__title">Holdings</h3>
+  <table class="table">
+    <thead><tr>
+      <th>Symbol</th><th class="num">Shares</th><th class="num">Avg cost</th><th class="num">Price</th><th class="num">Market value</th><th class="num">Gain / loss</th><th></th>
+    </tr></thead>
+    <tbody>
+      @for (h of holdings(); track h.symbol) {
+        <tr>
+          <td class="mono strong">{{ h.symbol }}</td>
+          <td class="num tabular">{{ h.shares }}</td>
+          <td class="num tabular">{{ h.avgCostLabel }}</td>
+          <td class="num tabular">{{ h.priceLabel }}</td>
+          <td class="num tabular">{{ h.valueLabel }}</td>
+          <td class="num tabular">
+            @if (h.isUp) { <span class="text-up">{{ h.gainLabel }}</span> } @else { <span class="text-down">{{ h.gainLabel }}</span> }
+          </td>
+          <td class="num nowrap">
+            <button class="btn btn--success btn--sm" (click)="openTicket(h.symbol, 'buy')">Buy</button>
+            <button class="btn btn--outline btn--sm" (click)="openTicket(h.symbol, 'sell')">Sell</button>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>
+</div>
+}
+
+@if (screen() === 'orders') {
+<div class="card table-card">
+  <h1 class="orders-title">Order activity</h1>
+  <table class="table">
+    <thead><tr>
+      <th>Order</th><th>Date</th><th>Symbol</th><th>Side</th><th>Type</th><th class="num">Qty</th><th class="num">Price</th><th class="num">Total</th><th>Status</th>
+    </tr></thead>
+    <tbody>
+      @for (o of orderRows(); track o.id) {
+        <tr>
+          <td class="mono">{{ o.id }}</td>
+          <td class="muted">{{ o.date }}</td>
+          <td class="mono strong">{{ o.symbol }}</td>
+          <td class="capitalize">{{ o.side }}</td>
+          <td>{{ o.type }}</td>
+          <td class="num tabular">{{ o.qty }}</td>
+          <td class="num tabular">{{ o.priceLabel }}</td>
+          <td class="num tabular">{{ o.totalLabel }}</td>
+          <td>
+            @if (o.isFilled) { <span class="badge badge--success">Filled</span> }
+            @if (o.isPending) { <span class="badge badge--info">Pending</span> }
+            @if (o.isCanceled) { <span class="badge badge--muted">Canceled</span> }
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>
+}
+
+@if (screen() === 'account') {
+<div class="account-stack">
+  <div class="card account-profile">
+    <div class="avatar">JR</div>
+    <div>
+      <div class="account-name">Jamie Rivera</div>
+      <div class="muted-note">jamie.rivera&#64;example.com · Account #4417-002</div>
+    </div>
+  </div>
+
+  <div class="card settings-card">
+    <h3 class="card__title">Appearance</h3>
+    <div class="setting-row">
+      <div><div class="setting-row__label">Dark theme</div><div class="muted-note">Switch between light and dark</div></div>
+      <button class="switch" [class.switch--on]="theme() === 'dark'" [attr.aria-pressed]="theme() === 'dark'" (click)="toggleTheme()"><span></span></button>
+    </div>
+  </div>
+
+  <div class="card settings-card">
+    <h3 class="card__title">Notifications</h3>
+    @for (t of notifRows(); track t.key) {
+      <div class="setting-row">
+        <div><div class="setting-row__label">{{ t.label }}</div><div class="muted-note">{{ t.sub }}</div></div>
+        <button class="switch" [class.switch--on]="t.on" [attr.aria-pressed]="t.on" (click)="toggleNotif(t.key)"><span></span></button>
+      </div>
+    }
+  </div>
+
+  <div class="card settings-card">
+    <h3 class="card__title">Security</h3>
+    <div class="setting-row">
+      <div><div class="setting-row__label">Two-factor authentication</div><div class="muted-note">Require a code at sign-in</div></div>
+      <button class="switch" [class.switch--on]="twoFactor()" [attr.aria-pressed]="twoFactor()" (click)="toggleTwoFactor()"><span></span></button>
+    </div>
+    <button class="btn btn--secondary" style="justify-self:start">Change password</button>
+    <button class="btn btn--ghost" style="justify-self:start">Sign out</button>
+  </div>
+</div>
+}
+
+</main>
+</div>
+
+@if (ticketView(); as tv) {
+<div class="modal-backdrop">
+<div class="modal">
+
+@if (tv.step === 'ticket') {
+  <div class="modal-header">
+    <h3 class="modal-title">{{ tv.verb }} {{ tv.symbol }}</h3>
+    <button class="icon-btn" (click)="closeTicket()" aria-label="Close">&times;</button>
+  </div>
+  <div class="side-toggle">
+    <button class="side-btn" [class.side-btn--buy-active]="tv.side === 'buy'" (click)="updateTicket({ side: 'buy' })">Buy</button>
+    <button class="side-btn" [class.side-btn--sell-active]="tv.side === 'sell'" (click)="updateTicket({ side: 'sell' })">Sell</button>
+  </div>
+  <div class="ticket-fields">
+    <div>
+      <label class="field-label">Order type</label>
+      <select class="field-input" [ngModel]="tv.type" (ngModelChange)="updateTicket({ type: $event })">
+        <option value="market">Market</option>
+        <option value="limit">Limit</option>
+        <option value="stop">Stop</option>
+      </select>
+    </div>
+    <div>
+      <label class="field-label">Quantity (shares)</label>
+      <input type="number" min="1" class="field-input" [ngModel]="tv.qty" (ngModelChange)="updateTicket({ qty: $event })"/>
+    </div>
+    @if (tv.needsPrice) {
+      <div>
+        <label class="field-label">{{ tv.priceFieldLabel }}</label>
+        <input type="number" step="0.01" class="field-input" [ngModel]="tv.price" (ngModelChange)="updateTicket({ price: $event })"/>
+      </div>
+    }
+    <div class="est-row">
+      <span class="muted-note">Estimated total</span>
+      <span class="tabular">{{ tv.estLabel }}</span>
+    </div>
+  </div>
+  <div class="modal-actions">
+    <button class="btn btn--secondary" (click)="closeTicket()">Cancel</button>
+    <button class="btn btn--primary" (click)="reviewTicket()">Review order</button>
+  </div>
+}
+
+@if (tv.step === 'confirm') {
+  <h3 class="modal-title" style="margin-bottom:16px">Confirm order</h3>
+  <div class="confirm-rows">
+    <div class="confirm-row"><span class="muted-note">Symbol</span><span class="mono strong">{{ tv.symbol }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Side</span><span class="capitalize">{{ tv.side }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Type</span><span>{{ tv.typeLabel }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Quantity</span><span class="tabular">{{ tv.qty }} shares</span></div>
+    <div class="confirm-row"><span class="muted-note">Price</span><span class="tabular">{{ tv.priceLabel }}</span></div>
+    <div class="confirm-row confirm-row--total"><span>Estimated total</span><span class="tabular">{{ tv.estLabel }}</span></div>
+  </div>
+  <div class="warning-box"><p>Orders fill at the prevailing market price. Once filled, this can't be undone.</p></div>
+  <div class="modal-actions">
+    <button class="btn btn--secondary" (click)="backTicket()">Back</button>
+    <button class="btn btn--primary" (click)="placeOrder()">Place {{ tv.side }} order</button>
+  </div>
+}
+
+@if (tv.step === 'success') {
+  <div class="success-block">
+    <div class="success-icon"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="var(--acme-color-success)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>
+    <h3 class="modal-title">Order placed</h3>
+    <p class="muted-note">{{ tv.successSummary }}</p>
+    <p class="order-id">{{ tv.orderId }}</p>
+    <div class="modal-actions" style="margin-top:8px">
+      <button class="btn btn--secondary" (click)="closeTicket()">Done</button>
+      <button class="btn btn--primary" (click)="goToOrders()">View orders</button>
+    </div>
+  </div>
+}
+
+</div>
+</div>
+}

--- a/src/app/trading-app/trading-app.component.ts
+++ b/src/app/trading-app/trading-app.component.ts
@@ -1,0 +1,393 @@
+import { Component, computed, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+type Theme = 'dark' | 'light';
+type Screen = 'dashboard' | 'portfolio' | 'orders' | 'account';
+type CategoryId = 'watch' | 'stocks' | 'etfs' | 'crypto';
+type RangeId = '1D' | '1W' | '1M' | '3M' | '1Y';
+type Side = 'buy' | 'sell';
+type OrderType = 'market' | 'limit' | 'stop';
+type OrderStatus = 'filled' | 'pending' | 'canceled';
+type TicketStep = 'ticket' | 'confirm' | 'success';
+
+interface StockData {
+  name: string;
+  exch: string;
+  price: number;
+  chgPct: number;
+  open: number;
+  dayHigh: number;
+  dayLow: number;
+  wLow: number;
+  wHigh: number;
+  volume: number;
+  cap: string;
+}
+
+interface Holding {
+  symbol: string;
+  shares: number;
+  avgCost: number;
+}
+
+interface Order {
+  id: string;
+  date: string;
+  symbol: string;
+  side: Side;
+  type: string;
+  qty: number;
+  price: number;
+  status: OrderStatus;
+}
+
+interface TicketState {
+  symbol: string;
+  side: Side;
+  type: OrderType;
+  qty: string;
+  price: string;
+  step: TicketStep;
+  id?: string;
+  status?: OrderStatus;
+}
+
+interface ChartGeometry {
+  path: string;
+  areaPath: string;
+  rising: boolean;
+  falling: boolean;
+}
+
+const CATEGORY_SYMBOLS: Record<Exclude<CategoryId, 'watch'>, string[]> = {
+  stocks: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN', 'META', 'TSLA', 'JPM', 'NFLX', 'AMD'],
+  etfs: ['SPY', 'QQQ', 'VTI'],
+  crypto: ['BTC-USD', 'ETH-USD']
+};
+
+const STOCKS: Record<string, StockData> = {
+  AAPL: { name: 'Apple Inc.', exch: 'NASDAQ', price: 231.52, chgPct: 1.82, open: 228.10, dayHigh: 232.40, dayLow: 227.55, wLow: 164.08, wHigh: 237.23, volume: 58230000, cap: '3.58T' },
+  MSFT: { name: 'Microsoft Corporation', exch: 'NASDAQ', price: 468.20, chgPct: 0.64, open: 465.80, dayHigh: 470.10, dayLow: 464.20, wLow: 385.58, wHigh: 480.00, volume: 19850000, cap: '3.48T' },
+  NVDA: { name: 'NVIDIA Corporation', exch: 'NASDAQ', price: 142.85, chgPct: -1.24, open: 144.90, dayHigh: 145.60, dayLow: 141.90, wLow: 86.62, wHigh: 153.13, volume: 210450000, cap: '3.49T' },
+  GOOGL: { name: 'Alphabet Inc.', exch: 'NASDAQ', price: 191.40, chgPct: 2.05, open: 187.60, dayHigh: 192.80, dayLow: 187.10, wLow: 140.53, wHigh: 195.50, volume: 27340000, cap: '2.35T' },
+  AMZN: { name: 'Amazon.com, Inc.', exch: 'NASDAQ', price: 214.30, chgPct: 0.91, open: 212.50, dayHigh: 215.90, dayLow: 211.80, wLow: 151.61, wHigh: 220.53, volume: 34120000, cap: '2.27T' },
+  META: { name: 'Meta Platforms, Inc.', exch: 'NASDAQ', price: 612.75, chgPct: 1.14, open: 605.90, dayHigh: 615.20, dayLow: 604.10, wLow: 414.50, wHigh: 638.40, volume: 12870000, cap: '1.55T' },
+  TSLA: { name: 'Tesla, Inc.', exch: 'NASDAQ', price: 268.90, chgPct: -3.37, open: 279.40, dayHigh: 281.00, dayLow: 267.55, wLow: 138.80, wHigh: 488.54, volume: 98450000, cap: '860.2B' },
+  JPM: { name: 'JPMorgan Chase & Co.', exch: 'NYSE', price: 231.10, chgPct: 0.28, open: 230.30, dayHigh: 232.60, dayLow: 229.40, wLow: 179.20, wHigh: 245.10, volume: 8320000, cap: '650.4B' },
+  NFLX: { name: 'Netflix, Inc.', exch: 'NASDAQ', price: 985.40, chgPct: -0.52, open: 990.10, dayHigh: 995.80, dayLow: 981.20, wLow: 585.28, wHigh: 1064.50, volume: 2140000, cap: '425.1B' },
+  AMD: { name: 'Advanced Micro Devices', exch: 'NASDAQ', price: 168.20, chgPct: 2.71, open: 163.80, dayHigh: 169.40, dayLow: 163.10, wLow: 93.12, wHigh: 187.28, volume: 45230000, cap: '272.6B' },
+  SPY: { name: 'SPDR S&P 500 ETF Trust', exch: 'NYSEARCA', price: 612.34, chgPct: 0.42, open: 609.80, dayHigh: 613.50, dayLow: 608.90, wLow: 493.05, wHigh: 618.30, volume: 62340000, cap: '—' },
+  QQQ: { name: 'Invesco QQQ Trust', exch: 'NASDAQ', price: 524.18, chgPct: 0.58, open: 521.30, dayHigh: 526.00, dayLow: 520.60, wLow: 402.39, wHigh: 530.20, volume: 41230000, cap: '—' },
+  VTI: { name: 'Vanguard Total Stock Market ETF', exch: 'NYSEARCA', price: 312.66, chgPct: 0.39, open: 311.20, dayHigh: 313.50, dayLow: 310.80, wLow: 246.05, wHigh: 315.90, volume: 3120000, cap: '—' },
+  'BTC-USD': { name: 'Bitcoin', exch: 'Crypto', price: 118420.00, chgPct: 2.15, open: 115900, dayHigh: 119800, dayLow: 114600, wLow: 52150, wHigh: 124500, volume: 0, cap: '2.35T' },
+  'ETH-USD': { name: 'Ethereum', exch: 'Crypto', price: 4380.50, chgPct: -1.05, open: 4428.00, dayHigh: 4455.00, dayLow: 4350.00, wLow: 1890.40, wHigh: 4820.00, volume: 0, cap: '528.4B' }
+};
+
+const HOLDINGS: Holding[] = [
+  { symbol: 'AAPL', shares: 40, avgCost: 189.40 },
+  { symbol: 'MSFT', shares: 15, avgCost: 365.20 },
+  { symbol: 'NVDA', shares: 60, avgCost: 98.75 },
+  { symbol: 'TSLA', shares: 20, avgCost: 240.60 },
+  { symbol: 'GOOGL', shares: 25, avgCost: 150.30 },
+  { symbol: 'QQQ', shares: 30, avgCost: 480.10 }
+];
+
+const ORDER_HISTORY: Order[] = [
+  { id: 'ORD-10482', date: 'Jul 16, 2026', symbol: 'AAPL', side: 'buy', type: 'Market', qty: 10, price: 229.80, status: 'filled' },
+  { id: 'ORD-10475', date: 'Jul 15, 2026', symbol: 'TSLA', side: 'sell', type: 'Limit', qty: 5, price: 275.00, status: 'filled' },
+  { id: 'ORD-10461', date: 'Jul 14, 2026', symbol: 'NVDA', side: 'buy', type: 'Limit', qty: 20, price: 140.00, status: 'pending' },
+  { id: 'ORD-10450', date: 'Jul 12, 2026', symbol: 'MSFT', side: 'buy', type: 'Market', qty: 8, price: 462.10, status: 'filled' },
+  { id: 'ORD-10439', date: 'Jul 10, 2026', symbol: 'GOOGL', side: 'sell', type: 'Stop', qty: 12, price: 182.50, status: 'canceled' },
+  { id: 'ORD-10422', date: 'Jul 8, 2026', symbol: 'AMD', side: 'buy', type: 'Market', qty: 25, price: 159.40, status: 'filled' },
+  { id: 'ORD-10410', date: 'Jul 6, 2026', symbol: 'QQQ', side: 'buy', type: 'Market', qty: 15, price: 518.30, status: 'filled' },
+  { id: 'ORD-10398', date: 'Jul 3, 2026', symbol: 'META', side: 'sell', type: 'Limit', qty: 4, price: 625.00, status: 'pending' }
+];
+
+const CATEGORIES: { id: CategoryId; label: string }[] = [
+  { id: 'watch', label: 'Watch' },
+  { id: 'stocks', label: 'Stocks' },
+  { id: 'etfs', label: 'ETFs' },
+  { id: 'crypto', label: 'Crypto' }
+];
+
+const NAV: { id: Screen; label: string }[] = [
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'portfolio', label: 'Portfolio' },
+  { id: 'orders', label: 'Orders' },
+  { id: 'account', label: 'Account' }
+];
+
+const RANGE_COUNTS: Record<RangeId, number> = { '1D': 24, '1W': 28, '1M': 30, '3M': 45, '1Y': 52 };
+const ALLOC_COLORS = ['#2563EB', '#3b7bf0', '#5c93f4', '#7ba9f7', '#9cbff9', '#bdd5fc'];
+const NEWS_PUBLISHERS = ['Market Wire', 'Ticker Daily', 'Desk Notes'];
+
+function fmtMoney(v: number | null | undefined): string {
+  if (v == null || isNaN(v)) return '—';
+  return '$' + v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+function fmtPct(v: number): string {
+  const sign = v >= 0 ? '+' : '';
+  return sign + v.toFixed(2) + '%';
+}
+function fmtNum(v: number): string {
+  if (!v) return '—';
+  if (v >= 1e9) return (v / 1e9).toFixed(2) + 'B';
+  if (v >= 1e6) return (v / 1e6).toFixed(2) + 'M';
+  if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+  return String(v);
+}
+function seededSeries(seedStr: string, base: number, count: number): number[] {
+  let h = 0;
+  for (let i = 0; i < seedStr.length; i++) h = (h * 31 + seedStr.charCodeAt(i)) | 0;
+  function rnd() {
+    h ^= h << 13; h ^= h >>> 17; h ^= h << 5;
+    return ((h >>> 0) % 1000) / 1000;
+  }
+  let v = base * 0.9;
+  const pts: number[] = [];
+  for (let i = 0; i < count; i++) {
+    v += (rnd() - 0.47) * base * 0.018;
+    v = Math.max(base * 0.75, Math.min(base * 1.15, v));
+    pts.push(v);
+  }
+  pts[pts.length - 1] = base;
+  return pts;
+}
+function buildChart(points: number[]): ChartGeometry {
+  const width = 800, height = 220, padTop = 16, padBottom = 16;
+  const min = Math.min(...points), max = Math.max(...points), span = (max - min) || 1;
+  const innerH = height - padTop - padBottom;
+  const xy = points.map((p, i) => {
+    const x = (i / (points.length - 1)) * width;
+    const y = padTop + innerH - ((p - min) / span) * innerH;
+    return { x, y };
+  });
+  const path = xy.map((pt, i) => (i === 0 ? 'M' : 'L') + pt.x.toFixed(2) + ',' + pt.y.toFixed(2)).join(' ');
+  const areaPath = path + ' L' + xy[xy.length - 1].x.toFixed(2) + ',' + (height - padBottom) + ' L' + xy[0].x.toFixed(2) + ',' + (height - padBottom) + ' Z';
+  const rising = points[points.length - 1] >= points[0];
+  return { path, areaPath, rising, falling: !rising };
+}
+
+@Component({
+  selector: 'app-trading-app',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './trading-app.component.html',
+  styleUrl: './trading-app.component.css'
+})
+export class TradingAppComponent {
+  readonly nav = NAV;
+  readonly categories = CATEGORIES;
+  readonly rangesIds: RangeId[] = ['1D', '1W', '1M', '3M', '1Y'];
+
+  theme = signal<Theme>((document.documentElement.getAttribute('data-theme') as Theme) || 'dark');
+  screen = signal<Screen>('dashboard');
+  category = signal<CategoryId>('watch');
+  activeSymbol = signal('AAPL');
+  range = signal<RangeId>('1M');
+  watchlist = signal<string[]>(['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'TSLA']);
+  searchQuery = signal('');
+  ticket = signal<TicketState | null>(null);
+  orders = signal<Order[]>(ORDER_HISTORY.slice());
+  notif = signal({ price: true, fills: true, news: false });
+  twoFactor = signal(true);
+
+  toggleTheme() {
+    const next: Theme = this.theme() === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    this.theme.set(next);
+  }
+  setScreen(s: Screen) { this.screen.set(s); }
+  setCategory(c: CategoryId) { this.category.set(c); }
+  selectSymbol(sym: string) { this.activeSymbol.set(sym); this.searchQuery.set(''); }
+  setRange(r: RangeId) { this.range.set(r); }
+  toggleWatch(sym: string) {
+    this.watchlist.update(list => list.includes(sym) ? list.filter(x => x !== sym) : [...list, sym]);
+  }
+  onSearchChange(value: string) { this.searchQuery.set(value); }
+
+  openTicket(symbol: string, side: Side) {
+    this.ticket.set({ symbol, side, type: 'market', qty: '10', price: '', step: 'ticket' });
+  }
+  updateTicket(patch: Partial<TicketState>) {
+    this.ticket.update(t => t ? { ...t, ...patch } : t);
+  }
+  reviewTicket() { this.updateTicket({ step: 'confirm' }); }
+  backTicket() { this.updateTicket({ step: 'ticket' }); }
+  placeOrder() {
+    const t = this.ticket();
+    if (!t) return;
+    const stock = STOCKS[t.symbol];
+    const price = t.type === 'market' ? stock.price : (parseFloat(t.price) || stock.price);
+    const qty = parseInt(t.qty, 10) || 0;
+    const id = 'ORD-' + Math.floor(10500 + Math.random() * 400);
+    const status: OrderStatus = t.type === 'market' ? 'filled' : 'pending';
+    const typeLabel = t.type === 'market' ? 'Market' : t.type === 'limit' ? 'Limit' : 'Stop';
+    const order: Order = { id, date: 'Jul 17, 2026', symbol: t.symbol, side: t.side, type: typeLabel, qty, price, status };
+    this.orders.update(list => [order, ...list]);
+    this.ticket.set({ ...t, step: 'success', id, status, price: String(price), qty: String(qty) });
+  }
+  closeTicket() { this.ticket.set(null); }
+  goToOrders() { this.ticket.set(null); this.screen.set('orders'); }
+  toggleNotif(key: 'price' | 'fills' | 'news') {
+    this.notif.update(n => ({ ...n, [key]: !n[key] }));
+  }
+  toggleTwoFactor() { this.twoFactor.update(v => !v); }
+
+  // ---------- Derived view data ----------
+
+  readonly stockData = computed(() => STOCKS[this.activeSymbol()]);
+
+  readonly stock = computed(() => {
+    const d = this.stockData();
+    const change = d.price * d.chgPct / 100;
+    const isUp = change >= 0;
+    return {
+      symbol: this.activeSymbol(),
+      name: d.name,
+      exch: d.exch,
+      priceLabel: fmtMoney(d.price),
+      changeLabel: (isUp ? '+' : '') + change.toFixed(2),
+      changePctLabel: fmtPct(d.chgPct),
+      isUp, isDown: !isUp,
+      isWatched: this.watchlist().includes(this.activeSymbol())
+    };
+  });
+
+  readonly chart = computed(() => {
+    const series = seededSeries(this.activeSymbol() + this.range(), this.stockData().price, RANGE_COUNTS[this.range()]);
+    return buildChart(series);
+  });
+
+  readonly stats = computed(() => {
+    const d = this.stockData();
+    const change = d.price * d.chgPct / 100;
+    const prevClose = d.price - change;
+    return [
+      { label: 'Prev close', value: fmtMoney(prevClose) },
+      { label: 'Day range', value: fmtMoney(d.dayLow) + ' – ' + fmtMoney(d.dayHigh) },
+      { label: '52W range', value: fmtMoney(d.wLow) + ' – ' + fmtMoney(d.wHigh) },
+      { label: 'Volume', value: fmtNum(d.volume) },
+      { label: 'Market cap', value: d.cap },
+      { label: 'Exchange', value: d.exch }
+    ];
+  });
+
+  readonly news = computed(() => {
+    const d = this.stockData();
+    const sym = this.activeSymbol();
+    return [
+      { title: d.name + ' extends move as investors weigh the outlook', publisher: NEWS_PUBLISHERS[0], time: '2h ago' },
+      { title: 'Analysts split on ' + sym + ' after latest guidance', publisher: NEWS_PUBLISHERS[1], time: '6h ago' },
+      { title: 'What to watch in ' + d.name + ' shares this week', publisher: NEWS_PUBLISHERS[2], time: '1d ago' }
+    ];
+  });
+
+  readonly rows = computed(() => {
+    const cat = this.category();
+    const symbols = cat === 'watch' ? this.watchlist() : CATEGORY_SYMBOLS[cat];
+    return symbols.map(sym => {
+      const d = STOCKS[sym];
+      const c = d.price * d.chgPct / 100;
+      const up = c >= 0;
+      return {
+        symbol: sym, name: d.name, priceLabel: fmtMoney(d.price),
+        changeLabel: fmtPct(d.chgPct), isUp: up, isDown: !up,
+        isActive: sym === this.activeSymbol()
+      };
+    });
+  });
+
+  readonly searchResults = computed(() => {
+    const q = this.searchQuery().trim().toLowerCase();
+    if (!q) return [];
+    return Object.keys(STOCKS)
+      .filter(sym => sym.toLowerCase().includes(q) || STOCKS[sym].name.toLowerCase().includes(q))
+      .slice(0, 8)
+      .map(sym => ({ symbol: sym, name: STOCKS[sym].name }));
+  });
+
+  readonly holdings = computed(() => {
+    return HOLDINGS.map(h => {
+      const d = STOCKS[h.symbol];
+      const value = h.shares * d.price;
+      const cost = h.shares * h.avgCost;
+      const gain = value - cost;
+      const up = gain >= 0;
+      return {
+        symbol: h.symbol, shares: h.shares, avgCostLabel: fmtMoney(h.avgCost), priceLabel: fmtMoney(d.price),
+        valueLabel: fmtMoney(value), gainLabel: (up ? '+' : '') + fmtMoney(gain),
+        isUp: up, isDown: !up
+      };
+    });
+  });
+
+  readonly portfolio = computed(() => {
+    let totalValue = 0, totalCost = 0, dayChange = 0;
+    HOLDINGS.forEach(h => {
+      const d = STOCKS[h.symbol];
+      const value = h.shares * d.price;
+      totalValue += value;
+      totalCost += h.shares * h.avgCost;
+      dayChange += value * d.chgPct / 100;
+    });
+    const totalGain = totalValue - totalCost;
+    const gainUp = totalGain >= 0;
+    const dayUp = dayChange >= 0;
+    const allocation = HOLDINGS.map((h, i) => {
+      const d = STOCKS[h.symbol];
+      const value = h.shares * d.price;
+      const pct = totalValue ? (value / totalValue) * 100 : 0;
+      return { symbol: h.symbol, pct, pctLabel: pct.toFixed(1) + '%', color: ALLOC_COLORS[i % ALLOC_COLORS.length] };
+    });
+    return {
+      totalLabel: fmtMoney(totalValue),
+      dayLabel: (dayUp ? '+' : '') + fmtMoney(dayChange), dayUp, dayDown: !dayUp,
+      gainLabel: (gainUp ? '+' : '') + fmtMoney(totalGain), gainUp, gainDown: !gainUp,
+      gainPctLabel: fmtPct(totalCost ? (totalGain / totalCost) * 100 : 0),
+      allocation
+    };
+  });
+
+  readonly orderRows = computed(() => this.orders().map(o => ({
+    id: o.id, date: o.date, symbol: o.symbol, side: o.side, type: o.type, qty: o.qty,
+    priceLabel: fmtMoney(o.price), totalLabel: fmtMoney(o.qty * o.price),
+    isFilled: o.status === 'filled', isPending: o.status === 'pending', isCanceled: o.status === 'canceled'
+  })));
+
+  readonly notifRows = computed(() => {
+    const n = this.notif();
+    return [
+      { key: 'price' as const, label: 'Price alerts', sub: 'Notify on watchlist price moves', on: n.price },
+      { key: 'fills' as const, label: 'Order fills', sub: 'Notify when an order fills', on: n.fills },
+      { key: 'news' as const, label: 'News digest', sub: 'Daily summary for your watchlist', on: n.news }
+    ];
+  });
+
+  readonly ticketView = computed(() => {
+    const t = this.ticket();
+    if (!t) return null;
+    const td = STOCKS[t.symbol];
+    const qty = parseInt(t.qty, 10) || 0;
+    const est = t.type === 'market' ? td.price * qty : (parseFloat(t.price) || td.price) * qty;
+    return {
+      symbol: t.symbol,
+      side: t.side,
+      verb: t.side === 'buy' ? 'Buy' : 'Sell',
+      type: t.type,
+      typeLabel: t.type === 'market' ? 'Market' : t.type === 'limit' ? 'Limit' : 'Stop',
+      qty: t.qty,
+      price: t.price,
+      priceLabel: t.type === 'market' ? 'Market price (' + fmtMoney(td.price) + ')' : fmtMoney(parseFloat(t.price) || td.price),
+      estLabel: fmtMoney(est),
+      needsPrice: t.type !== 'market',
+      priceFieldLabel: t.type === 'limit' ? 'Limit price' : 'Stop price',
+      step: t.step,
+      orderId: t.id || '',
+      successSummary: t.step === 'success'
+        ? (t.side === 'buy' ? 'Bought ' : 'Sold ') + t.qty + ' shares of ' + t.symbol +
+          (t.status === 'pending' ? ' — pending fill.' : ' — filled at ' + fmtMoney(parseFloat(t.price)) + '.')
+        : ''
+    };
+  });
+}

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;600;700;800&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600&display=swap" rel="stylesheet">
   <script>
     (function () {
       try {

--- a/src/styles/acme-tokens.css
+++ b/src/styles/acme-tokens.css
@@ -1,0 +1,145 @@
+/* ACME Corp design tokens, imported from the "Stock Trading App" Claude Design
+   project (design system: acme-design-system-739be177-5fe1-4acc-9faa-65671c99d370).
+   Scoped by --acme- prefix so it can't collide with the app's own theme vars. */
+:root {
+  color-scheme: light dark;
+
+  --acme-red-50: #FDF3F4;
+  --acme-red-100: #FAE3E6;
+  --acme-red-200: #F5C2C9;
+  --acme-red-300: #EC93A0;
+  --acme-red-400: #E05C70;
+  --acme-red-500: #D22F4C;
+  --acme-red-600: #C8102E;
+  --acme-red-700: #A60D26;
+  --acme-red-800: #8A0F23;
+  --acme-red-900: #741122;
+  --acme-red-950: #43060F;
+
+  --acme-gray-0: #FFFFFF;
+  --acme-gray-50: #F8F9FA;
+  --acme-gray-100: #F1F3F5;
+  --acme-gray-200: #E4E7EB;
+  --acme-gray-300: #CDD2D9;
+  --acme-gray-400: #9AA1AC;
+  --acme-gray-500: #6C7480;
+  --acme-gray-600: #4E5560;
+  --acme-gray-700: #3A404A;
+  --acme-gray-800: #262B33;
+  --acme-gray-900: #16191F;
+  --acme-gray-950: #0C0E12;
+
+  --acme-blue-50: #EFF4FE;
+  --acme-blue-100: #DEE9FD;
+  --acme-blue-200: #BCD2FA;
+  --acme-blue-300: #8FB0F5;
+  --acme-blue-400: #5F88EE;
+  --acme-blue-500: #3B82F6;
+  --acme-blue-600: #2563EB;
+  --acme-blue-700: #1D4ED8;
+
+  --acme-green-50: #F0FBF4;
+  --acme-green-300: #7FD99A;
+  --acme-green-400: #4CBB74;
+  --acme-green-500: #22C55E;
+  --acme-green-600: #15803D;
+  --acme-green-700: #116932;
+
+  --acme-amber-50: #FEF8EB;
+  --acme-amber-300: #FCD34D;
+  --acme-amber-500: #F59E0B;
+  --acme-amber-700: #B45309;
+  --acme-amber-800: #92400E;
+
+  --acme-font-sans: "Inter", "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  --acme-font-display: "Archivo", "Inter", "Segoe UI", system-ui, sans-serif;
+  --acme-font-mono: "JetBrains Mono", ui-monospace, "Cascadia Code", Consolas, monospace;
+
+  --acme-radius-sm: 6px;
+  --acme-radius-md: 12px;
+  --acme-radius-lg: 20px;
+  --acme-radius-xl: 28px;
+  --acme-radius-full: 999px;
+
+  --acme-shadow-sm: 0 1px 2px rgb(12 14 18 / 0.08);
+  --acme-shadow-md: 0 4px 12px -2px rgb(12 14 18 / 0.12);
+  --acme-shadow-lg: 0 12px 32px -8px rgb(12 14 18 / 0.16);
+
+  --acme-glass-blur: 24px;
+  --acme-glass-saturate: 160%;
+  --acme-material-glass: color-mix(in srgb, var(--acme-gray-0) 62%, transparent);
+  --acme-material-glass-strong: color-mix(in srgb, var(--acme-gray-0) 85%, transparent);
+  --acme-glass-edge: inset 0 1px 0 rgb(255 255 255 / 0.65), inset 0 0 0 1px rgb(255 255 255 / 0.28);
+
+  --acme-color-canvas: var(--acme-gray-0);
+  --acme-color-surface: var(--acme-gray-50);
+  --acme-color-surface-raised: var(--acme-gray-0);
+  --acme-color-border: var(--acme-gray-200);
+  --acme-color-border-strong: var(--acme-gray-300);
+  --acme-color-text: var(--acme-gray-900);
+  --acme-color-text-muted: var(--acme-gray-600);
+  --acme-color-text-subtle: var(--acme-gray-500);
+  --acme-color-primary: var(--acme-red-600);
+  --acme-color-primary-hover: var(--acme-red-700);
+  --acme-color-primary-active: var(--acme-red-800);
+  --acme-color-on-primary: var(--acme-gray-0);
+  --acme-color-link: var(--acme-red-700);
+  --acme-color-focus: var(--acme-blue-500);
+  --acme-color-success: var(--acme-green-600);
+  --acme-color-success-soft: var(--acme-green-50);
+  --acme-color-success-soft-text: var(--acme-green-700);
+  --acme-color-warning: var(--acme-amber-700);
+  --acme-color-warning-soft: var(--acme-amber-50);
+  --acme-color-warning-soft-text: var(--acme-amber-800);
+  --acme-color-danger: var(--acme-red-700);
+  --acme-color-danger-emphasis: var(--acme-red-700);
+  --acme-color-danger-soft: var(--acme-red-50);
+  --acme-color-danger-soft-text: var(--acme-red-700);
+  --acme-color-info: var(--acme-blue-600);
+  --acme-color-info-soft: var(--acme-blue-50);
+  --acme-color-info-soft-text: var(--acme-blue-700);
+
+  accent-color: var(--acme-color-primary);
+}
+
+:root[data-theme="dark"] {
+  --acme-color-canvas: var(--acme-gray-950);
+  --acme-color-surface: var(--acme-gray-900);
+  --acme-color-surface-raised: var(--acme-gray-800);
+  --acme-color-border: var(--acme-gray-700);
+  --acme-color-border-strong: var(--acme-gray-600);
+  --acme-color-text: var(--acme-gray-100);
+  --acme-color-text-muted: var(--acme-gray-400);
+  --acme-color-text-subtle: var(--acme-gray-400);
+  --acme-color-primary: var(--acme-red-500);
+  --acme-color-primary-hover: var(--acme-red-400);
+  --acme-color-primary-active: var(--acme-red-600);
+  --acme-color-link: var(--acme-red-300);
+  --acme-color-focus: var(--acme-blue-400);
+  --acme-color-success: var(--acme-green-400);
+  --acme-color-success-soft: color-mix(in oklab, var(--acme-green-500) 16%, var(--acme-gray-900));
+  --acme-color-success-soft-text: var(--acme-green-300);
+  --acme-color-warning: var(--acme-amber-500);
+  --acme-color-warning-soft: color-mix(in oklab, var(--acme-amber-500) 16%, var(--acme-gray-900));
+  --acme-color-warning-soft-text: var(--acme-amber-300);
+  --acme-color-danger: var(--acme-red-400);
+  --acme-color-danger-emphasis: var(--acme-red-500);
+  --acme-color-danger-soft: color-mix(in oklab, var(--acme-red-500) 18%, var(--acme-gray-900));
+  --acme-color-danger-soft-text: var(--acme-red-300);
+  --acme-color-info: var(--acme-blue-400);
+  --acme-color-info-soft: color-mix(in oklab, var(--acme-blue-500) 16%, var(--acme-gray-900));
+  --acme-color-info-soft-text: var(--acme-blue-300);
+  --acme-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.4);
+  --acme-shadow-md: 0 4px 12px -2px rgb(0 0 0 / 0.5);
+  --acme-shadow-lg: 0 12px 32px -8px rgb(0 0 0 / 0.6);
+  --acme-material-glass: color-mix(in srgb, var(--acme-gray-900) 70%, transparent);
+  --acme-material-glass-strong: color-mix(in srgb, var(--acme-gray-900) 90%, transparent);
+  --acme-glass-edge:
+    inset 0 1px 0 rgb(255 255 255 / 0.14),
+    inset 0 0 0 1px rgb(255 255 255 / 0.07);
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+}


### PR DESCRIPTION
## Summary
- Imports the "Stock Trading App" mockup from the Claude Design project (`015d46d8-065a-48b7-a81c-052820fa56b9`) and implements it as a new standalone `TradingAppComponent`, reachable at `/trading`.
- Ports the design's ACME design-system tokens (colors, typography, glass materials, shadows) into `src/styles/acme-tokens.css`, registered as a global stylesheet in `angular.json`; adds the Archivo font to `index.html`.
- Covers all four screens from the design: **Dashboard** (price chart, stats, news, watchlist/search), **Portfolio** (allocation + holdings table), **Orders** (history table), **Account** (settings/toggles) — plus the buy/sell order ticket modal flow (ticket → confirm → success). State is signal-based; mock quote/holdings/order data is ported verbatim from the design's embedded script.
- Adds routing (previously an empty `Routes` array) so the existing live-data Stockwatch app stays at `/` and the new design lives at `/trading`. `AppComponent` now renders a `<router-outlet>` instead of hardcoding `<app-stock>`.

## Test plan
- [x] `ng build` compiles cleanly with Angular's strict template type-checker
- [x] Verified both `/` and `/trading` serve correctly via the dev server, and the bundled JS passes a syntax check
- [ ] Manual visual check in a real browser — no working Chrome binary was available in this environment's architecture to capture a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)