### PR TITLE
Implement Stock Trading App Mobile design as a new /trading-mobile route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,10 @@
 import { Routes } from '@angular/router';
 import { StockComponent } from './stock/stock.component';
 import { TradingAppComponent } from './trading-app/trading-app.component';
+import { TradingAppMobileComponent } from './trading-app-mobile/trading-app-mobile.component';
 
 export const routes: Routes = [
   { path: '', component: StockComponent },
-  { path: 'trading', component: TradingAppComponent }
+  { path: 'trading', component: TradingAppComponent },
+  { path: 'trading-mobile', component: TradingAppMobileComponent }
 ];

--- a/src/app/trading-app-mobile/trading-app-mobile.component.css
+++ b/src/app/trading-app-mobile/trading-app-mobile.component.css
@@ -1,0 +1,243 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: var(--acme-color-surface);
+}
+
+a { color: var(--acme-color-link); text-decoration: none; }
+input, select { font-family: var(--acme-font-sans); }
+
+.stage {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 24px;
+}
+
+.device {
+  position: relative;
+  width: 402px;
+  height: 874px;
+  border-radius: 48px;
+  overflow: hidden;
+  background: #F2F2F7;
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.12);
+  font-family: -apple-system, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  color: var(--acme-color-text);
+}
+.device--dark { background: #000; }
+
+.dynamic-island {
+  position: absolute; top: 11px; left: 50%; transform: translateX(-50%);
+  width: 126px; height: 37px; border-radius: 24px; background: #000; z-index: 50;
+}
+
+.status-bar {
+  position: absolute; top: 0; left: 0; right: 0; z-index: 10;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 21px 24px 0;
+  box-sizing: border-box;
+  color: #000;
+}
+.device--dark .status-bar { color: #fff; }
+.status-bar__time { font: 590 17px -apple-system, "SF Pro", system-ui; }
+.status-bar__icons { display: flex; align-items: center; gap: 7px; }
+.status-bar__icons svg { fill: currentColor; stroke: currentColor; }
+
+.screen {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--acme-color-canvas);
+  color: var(--acme-color-text);
+  font-family: var(--acme-font-sans);
+}
+
+.content { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+.header { position: sticky; top: 0; z-index: 5; background: var(--acme-color-canvas); padding: 54px 20px 12px; flex: none; }
+.header__row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
+.large-title { font: 700 28px var(--acme-font-display); margin: 0; }
+
+.header--detail { display: flex; align-items: center; gap: 12px; padding: 54px 20px 8px; }
+.header--detail__title { flex: 1; font: 700 18px var(--acme-font-display); }
+
+.icon-btn {
+  width: 34px; height: 34px; border-radius: 999px; border: none; flex: none;
+  background: var(--acme-material-glass); display: grid; place-items: center; color: var(--acme-color-text); cursor: pointer;
+}
+.icon-btn--warning { background: var(--acme-color-warning-soft); color: var(--acme-color-warning-soft-text); }
+
+.search-box { display: flex; align-items: center; gap: 8px; height: 38px; border-radius: 999px; background: var(--acme-color-surface); padding: 0 14px; }
+.search-box__input { flex: 1; height: 100%; border: none; background: transparent; font: 14px var(--acme-font-sans); color: var(--acme-color-text); outline: none; }
+
+.body { padding: 4px 20px 110px; overflow: auto; flex: 1; }
+.body--detail { padding: 6px 20px 150px; }
+
+.muted-note { margin: 0; font-size: 13px; color: var(--acme-color-text-muted); }
+.mono { font-family: var(--acme-font-mono); }
+.strong { font: 700 14px var(--acme-font-mono); }
+.tabular { font-variant-numeric: tabular-nums; }
+.capitalize { text-transform: capitalize; }
+.text-up { color: var(--acme-color-success); font: 600 12px var(--acme-font-sans); }
+.text-down { color: var(--acme-color-danger); font: 600 12px var(--acme-font-sans); }
+
+.row-btn {
+  display: flex; justify-content: space-between; align-items: center; width: 100%; text-align: left;
+  padding: 12px 4px; border-bottom: 1px solid var(--acme-color-border); border-top: none; border-left: none; border-right: none;
+  background: transparent; cursor: pointer; font: 14px var(--acme-font-sans); color: var(--acme-color-text);
+}
+.row-btn--holding { padding: 13px 0; }
+.row-btn__name { flex: 1; margin-left: 10px; color: var(--acme-color-text-muted); font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.chip-row { display: flex; gap: 8px; overflow-x: auto; padding: 4px 0 14px; }
+.chip { flex: 0 0 auto; height: 32px; padding: 0 16px; border-radius: 999px; border: none; background: var(--acme-color-surface); font: 600 13px var(--acme-font-sans); color: var(--acme-color-text-muted); white-space: nowrap; cursor: pointer; }
+.chip--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); color: var(--acme-color-text); }
+
+.watch-row {
+  display: flex; justify-content: space-between; align-items: center; width: 100%; text-align: left;
+  padding: 13px 4px; border-bottom: 1px solid var(--acme-color-border); border-top: none; border-left: none; border-right: none;
+  background: transparent; cursor: pointer;
+}
+.watch-row__name { font: 12px var(--acme-font-sans); color: var(--acme-color-text-muted); max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.watch-row__right { text-align: right; }
+.watch-row__right .price { font: 600 14px var(--acme-font-sans); }
+
+.detail-sub { margin-bottom: 2px; }
+.detail-price { font: 700 34px var(--acme-font-display); font-variant-numeric: tabular-nums; margin: 6px 0 4px; }
+.change { display: inline-flex; align-items: center; gap: 6px; font: 600 14px var(--acme-font-sans); }
+.change--up { color: var(--acme-color-success); }
+.change--down { color: var(--acme-color-danger); }
+
+.range-group { display: inline-flex; gap: 2px; padding: 3px; border-radius: 999px; background: var(--acme-color-surface); margin: 16px 0 4px; }
+.range-btn { height: 28px; padding: 0 12px; border-radius: 999px; border: none; background: transparent; font: 600 11px var(--acme-font-sans); color: var(--acme-color-text-muted); cursor: pointer; }
+.range-btn--active { background: var(--acme-color-surface-raised); box-shadow: var(--acme-shadow-sm); color: var(--acme-color-text); }
+
+.chart-wrap { margin: 8px 0 14px; }
+.chart-svg { width: 100%; height: 160px; display: block; }
+.chart-line { stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; }
+.chart-line--up { stroke: var(--acme-color-success); }
+.chart-line--down { stroke: var(--acme-color-danger); }
+
+.stats-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 16px; padding: 16px 0; border-top: 1px solid var(--acme-color-border); }
+.stats-grid__label { font: 600 10.5px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em; color: var(--acme-color-text-muted); margin-bottom: 3px; }
+.stats-grid__value { font: 600 13px var(--acme-font-sans); font-variant-numeric: tabular-nums; }
+
+.section-title { font: 700 15px var(--acme-font-display); margin: 8px 0 4px; }
+.group-title { font: 700 13px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em; color: var(--acme-color-text-muted); margin: 16px 0 4px; }
+
+.news-item { padding: 11px 0; border-bottom: 1px solid var(--acme-color-border); }
+.news-item__title { font: 600 13px var(--acme-font-sans); margin-bottom: 3px; }
+.news-item__meta { font: 11px var(--acme-font-sans); color: var(--acme-color-text-muted); }
+
+.action-bar {
+  position: sticky; bottom: 0; z-index: 5; flex: none;
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-md);
+  padding: 12px 20px 30px;
+  display: flex; gap: 10px;
+}
+.btn { flex: 1; height: 44px; border-radius: 999px; border: none; cursor: pointer; font: 700 14px var(--acme-font-sans); }
+.btn--success { background: var(--acme-color-success); color: #fff; }
+.btn--outline { background: var(--acme-color-surface-raised); color: var(--acme-color-text); border: 1px solid var(--acme-color-border-strong); }
+.btn--primary { background: var(--acme-color-primary); color: #fff; }
+.btn--secondary { background: var(--acme-material-glass); box-shadow: var(--acme-glass-edge), var(--acme-shadow-sm); color: var(--acme-color-text); font-weight: 600; }
+.btn--full { width: 100%; height: 46px; font-size: 15px; margin-top: 16px; }
+
+.label-caps { font: 600 12px var(--acme-font-sans); text-transform: uppercase; letter-spacing: .04em; color: var(--acme-color-text-muted); margin-bottom: 4px; }
+.portfolio-total { font: 700 30px var(--acme-font-display); font-variant-numeric: tabular-nums; margin-bottom: 4px; }
+.portfolio-gain-line { margin-bottom: 4px; }
+.alloc-bar { display: flex; height: 10px; border-radius: 999px; overflow: hidden; margin: 16px 0; background: var(--acme-color-surface); }
+.alloc-bar > div { height: 100%; }
+
+.order-row { padding: 13px 0; border-bottom: 1px solid var(--acme-color-border); }
+.order-row__top { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+.order-row__bottom { display: flex; justify-content: space-between; font: 12px var(--acme-font-sans); color: var(--acme-color-text-muted); }
+
+.badge { font: 600 10.5px var(--acme-font-sans); border-radius: 999px; padding: 2px 9px; }
+.badge--success { background: var(--acme-color-success-soft); color: var(--acme-color-success-soft-text); }
+.badge--info { background: var(--acme-color-info-soft); color: var(--acme-color-info-soft-text); }
+.badge--muted { background: var(--acme-color-surface); color: var(--acme-color-text-muted); }
+
+.account-profile { display: flex; align-items: center; gap: 14px; padding: 14px 0; border-bottom: 1px solid var(--acme-color-border); }
+.avatar { width: 48px; height: 48px; border-radius: 999px; background: var(--acme-color-surface); display: grid; place-items: center; font: 700 16px var(--acme-font-display); }
+.account-name { font: 700 15px var(--acme-font-display); }
+
+.setting-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 0; border-bottom: 1px solid var(--acme-color-border); }
+.setting-row__label { font: 14px var(--acme-font-sans); }
+.switch { width: 44px; height: 26px; border-radius: 999px; border: none; padding: 2px; cursor: pointer; background: var(--acme-color-border-strong); display: flex; justify-content: flex-start; }
+.switch--on { background: var(--acme-color-success); justify-content: flex-end; }
+.switch span { width: 22px; height: 22px; border-radius: 999px; background: #fff; display: block; }
+
+.link-row { width: 100%; text-align: left; padding: 12px 0; background: none; border: none; font: 14px var(--acme-font-sans); color: var(--acme-color-link); cursor: pointer; border-bottom: 1px solid var(--acme-color-border); }
+.link-row--muted { padding: 14px 0; font-weight: 600; color: var(--acme-color-text-muted); border-bottom: none; }
+
+.tab-bar {
+  position: sticky; bottom: 0; z-index: 5; display: flex; flex: none;
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-md);
+  padding: 8px 8px 26px;
+}
+.tab-item {
+  flex: 1; display: flex; flex-direction: column; align-items: center; gap: 3px;
+  background: none; border: none; padding: 6px 0; cursor: pointer; color: var(--acme-color-text-muted);
+  font: 600 11px var(--acme-font-sans);
+}
+.tab-item--active { color: var(--acme-color-primary); }
+
+.sheet-backdrop {
+  position: absolute; inset: 0; background: rgb(12 14 18 / 0.3);
+  backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+  z-index: 40; display: flex; align-items: flex-end;
+}
+.sheet {
+  width: 100%; max-height: 86%;
+  background: var(--acme-material-glass-strong);
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  border-radius: 28px 28px 0 0;
+  box-shadow: var(--acme-glass-edge), var(--acme-shadow-lg);
+  padding: 10px 20px 34px;
+  overflow: auto;
+  box-sizing: border-box;
+}
+.sheet-handle { width: 36px; height: 4px; border-radius: 999px; background: var(--acme-color-border-strong); margin: 0 auto 16px; }
+.sheet-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+.sheet-title { font: 700 18px var(--acme-font-display); margin: 0; }
+
+.side-toggle { display: flex; gap: 8px; margin-bottom: 14px; }
+.side-btn {
+  flex: 1; height: 36px; border-radius: 999px; border: 1px solid var(--acme-color-border-strong); background: transparent;
+  color: var(--acme-color-text-muted); font: 600 13px var(--acme-font-sans); cursor: pointer;
+}
+.side-btn--buy-active { border: none; background: var(--acme-color-success); color: #fff; }
+.side-btn--sell-active { border: none; background: var(--acme-color-danger); color: #fff; }
+
+.ticket-fields { display: grid; gap: 12px; }
+.field-label { display: block; font: 600 12px var(--acme-font-sans); margin-bottom: 5px; }
+.field-input {
+  width: 100%; height: 40px; border-radius: 8px; border: 1px solid var(--acme-color-border-strong);
+  background: var(--acme-color-surface-raised); padding: 0 12px; font-size: 14px; color: var(--acme-color-text); box-sizing: border-box;
+}
+.est-row { display: flex; justify-content: space-between; padding: 10px 0; border-top: 1px solid var(--acme-color-border); font: 600 14px var(--acme-font-sans); }
+
+.confirm-rows { display: grid; gap: 9px; font: 14px var(--acme-font-sans); margin-bottom: 14px; }
+.confirm-row { display: flex; justify-content: space-between; }
+.confirm-row--total { padding-top: 9px; border-top: 1px solid var(--acme-color-border); font: 700 15px var(--acme-font-sans); }
+.warning-box { border: 1px solid var(--acme-color-border); border-left: 3px solid var(--acme-color-warning); border-radius: 8px; background: var(--acme-color-warning-soft); padding: 11px 13px; margin-bottom: 16px; }
+.warning-box p { margin: 0; font-size: 12.5px; color: var(--acme-color-warning-soft-text); }
+.sheet-actions { display: flex; gap: 10px; }
+.sheet-actions--full { margin-top: 6px; width: 100%; }
+.sheet-actions .btn { height: 44px; }
+
+.success-block { display: grid; justify-items: center; gap: 12px; text-align: center; padding: 10px 0 6px; }
+.success-icon { width: 52px; height: 52px; border-radius: 999px; background: var(--acme-color-success-soft); display: grid; place-items: center; }
+.order-id { margin: 0; font: 12px var(--acme-font-mono); color: var(--acme-color-text-subtle); }
+
+.screen::-webkit-scrollbar, .body::-webkit-scrollbar, .sheet::-webkit-scrollbar { display: none; }

--- a/src/app/trading-app-mobile/trading-app-mobile.component.html
+++ b/src/app/trading-app-mobile/trading-app-mobile.component.html
@@ -1,0 +1,316 @@
+<div class="stage">
+<div class="device" [class.device--dark]="theme() === 'dark'">
+
+<div class="dynamic-island"></div>
+<div class="status-bar">
+  <span class="status-bar__time">9:41</span>
+  <div class="status-bar__icons">
+    <svg width="19" height="12" viewBox="0 0 19 12"><rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7"/><rect x="4.8" y="5" width="3.2" height="7" rx="0.7"/><rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7"/><rect x="14.4" y="0" width="3.2" height="12" rx="0.7"/></svg>
+    <svg width="17" height="12" viewBox="0 0 17 12"><path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z"/><path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z"/><circle cx="8.5" cy="10.5" r="1.5"/></svg>
+    <svg width="27" height="13" viewBox="0 0 27 13"><rect x="0.5" y="0.5" width="23" height="12" rx="3.5" fill="none" stroke-opacity="0.35"/><rect x="2" y="2" width="20" height="9" rx="2"/></svg>
+  </div>
+</div>
+
+<div class="screen">
+
+@if (screen() === 'home') {
+<div class="content">
+  <div class="header">
+    <div class="header__row">
+      <h1 class="large-title">Watchlist</h1>
+      <button class="icon-btn" (click)="toggleTheme()" aria-label="Toggle theme">
+        @if (theme() === 'dark') {
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+        } @else {
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        }
+      </button>
+    </div>
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="var(--acme-color-text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      <input class="search-box__input" [ngModel]="searchQuery()" (ngModelChange)="onSearchChange($event)" placeholder="Search ticker or company"/>
+    </div>
+  </div>
+
+  <div class="body">
+    @if (searchQuery().trim().length > 0 && searchResults().length > 0) {
+      @for (m of searchResults(); track m.symbol) {
+        <button class="row-btn" (click)="selectSymbol(m.symbol)"><span class="mono strong">{{ m.symbol }}</span><span class="row-btn__name">{{ m.name }}</span></button>
+      }
+    } @else if (searchQuery().trim().length > 0) {
+      <p class="muted-note">No matches for &ldquo;{{ searchQuery() }}&rdquo;.</p>
+    } @else {
+      <div class="chip-row">
+        @for (c of categories; track c.id) {
+          <button class="chip" [class.chip--active]="category() === c.id" (click)="setCategory(c.id)">{{ c.label }}</button>
+        }
+      </div>
+      @for (w of rows(); track w.symbol) {
+        <button class="watch-row" (click)="selectSymbol(w.symbol)">
+          <div><div class="mono strong">{{ w.symbol }}</div><div class="watch-row__name">{{ w.name }}</div></div>
+          <div class="watch-row__right">
+            <div class="tabular price">{{ w.priceLabel }}</div>
+            @if (w.isUp) { <div class="text-up">{{ w.changeLabel }}</div> } @else { <div class="text-down">{{ w.changeLabel }}</div> }
+          </div>
+        </button>
+      }
+      @if (rows().length === 0) {
+        <p class="muted-note">No symbols yet. Search above and add to your watchlist.</p>
+      }
+    }
+  </div>
+</div>
+}
+
+@if (screen() === 'detail') {
+<div class="content">
+  <div class="header header--detail">
+    <button class="icon-btn" (click)="goHome()" aria-label="Back"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></button>
+    <div class="header--detail__title">{{ stock().symbol }}</div>
+    @if (stock().isWatched) {
+      <button class="icon-btn icon-btn--warning" (click)="toggleWatch(stock().symbol)"><svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" stroke="currentColor" stroke-width="1"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>
+    } @else {
+      <button class="icon-btn" (click)="toggleWatch(stock().symbol)"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>
+    }
+  </div>
+
+  <div class="body body--detail">
+    <div class="muted-note detail-sub">{{ stock().name }} · {{ stock().exch }}</div>
+    <div class="detail-price">{{ stock().priceLabel }}</div>
+    @if (stock().isUp) {
+      <div class="change change--up"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 15 12 9 18 15"/></svg>{{ stock().changeLabel }} ({{ stock().changePctLabel }})</div>
+    } @else {
+      <div class="change change--down"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>{{ stock().changeLabel }} ({{ stock().changePctLabel }})</div>
+    }
+
+    <div class="range-group" role="group">
+      @for (r of rangesIds; track r) {
+        <button class="range-btn" [class.range-btn--active]="range() === r" (click)="setRange(r)">{{ r }}</button>
+      }
+    </div>
+
+    <div class="chart-wrap">
+      <svg viewBox="0 0 360 160" preserveAspectRatio="none" class="chart-svg">
+        <defs>
+          <linearGradient id="mAreaUp" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" style="stop-color:var(--acme-color-success);stop-opacity:0.28"/><stop offset="100%" style="stop-color:var(--acme-color-success);stop-opacity:0"/></linearGradient>
+          <linearGradient id="mAreaDown" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" style="stop-color:var(--acme-color-danger);stop-opacity:0.28"/><stop offset="100%" style="stop-color:var(--acme-color-danger);stop-opacity:0"/></linearGradient>
+        </defs>
+        @if (chart().rising) {
+          <path [attr.d]="chart().areaPath" fill="url(#mAreaUp)"/>
+          <path [attr.d]="chart().path" fill="none" class="chart-line chart-line--up"/>
+        } @else {
+          <path [attr.d]="chart().areaPath" fill="url(#mAreaDown)"/>
+          <path [attr.d]="chart().path" fill="none" class="chart-line chart-line--down"/>
+        }
+      </svg>
+    </div>
+
+    <div class="stats-grid">
+      @for (s of stats(); track s.label) {
+        <div><div class="stats-grid__label">{{ s.label }}</div><div class="stats-grid__value">{{ s.value }}</div></div>
+      }
+    </div>
+
+    <h3 class="section-title">Latest news</h3>
+    @for (item of news(); track item.title) {
+      <div class="news-item">
+        <div class="news-item__title">{{ item.title }}</div>
+        <div class="news-item__meta">{{ item.publisher }} · {{ item.time }}</div>
+      </div>
+    }
+  </div>
+
+  <div class="action-bar">
+    <button class="btn btn--success" (click)="openTicket(stock().symbol, 'buy')">Buy</button>
+    <button class="btn btn--outline" (click)="openTicket(stock().symbol, 'sell')">Sell</button>
+  </div>
+</div>
+}
+
+@if (screen() === 'portfolio') {
+<div class="content">
+  <div class="header"><h1 class="large-title">Portfolio</h1></div>
+  <div class="body">
+    <div class="label-caps">Total value</div>
+    <div class="portfolio-total">{{ portfolio().totalLabel }}</div>
+    @if (portfolio().gainUp) {
+      <div class="text-up portfolio-gain-line">{{ portfolio().gainLabel }} ({{ portfolio().gainPctLabel }}) all time</div>
+    } @else {
+      <div class="text-down portfolio-gain-line">{{ portfolio().gainLabel }} ({{ portfolio().gainPctLabel }}) all time</div>
+    }
+
+    <div class="alloc-bar">
+      @for (a of portfolio().allocation; track a.symbol) {
+        <div [style.width.%]="a.pct" [style.background]="a.color"></div>
+      }
+    </div>
+
+    <h3 class="section-title">Holdings</h3>
+    @for (h of holdings(); track h.symbol) {
+      <button class="row-btn row-btn--holding" (click)="selectSymbol(h.symbol)">
+        <div><div class="mono strong">{{ h.symbol }}</div><div class="watch-row__name">{{ h.shares }} shares · avg {{ h.avgCostLabel }}</div></div>
+        <div class="watch-row__right">
+          <div class="tabular price">{{ h.valueLabel }}</div>
+          @if (h.isUp) { <div class="text-up">{{ h.gainLabel }}</div> } @else { <div class="text-down">{{ h.gainLabel }}</div> }
+        </div>
+      </button>
+    }
+  </div>
+</div>
+}
+
+@if (screen() === 'orders') {
+<div class="content">
+  <div class="header"><h1 class="large-title">Orders</h1></div>
+  <div class="body">
+    @for (o of orderRows(); track o.id) {
+      <div class="order-row">
+        <div class="order-row__top">
+          <div class="mono strong">{{ o.symbol }}</div>
+          @if (o.isFilled) { <span class="badge badge--success">Filled</span> }
+          @if (o.isPending) { <span class="badge badge--info">Pending</span> }
+          @if (o.isCanceled) { <span class="badge badge--muted">Canceled</span> }
+        </div>
+        <div class="order-row__bottom">
+          <span class="capitalize">{{ o.side }} · {{ o.type }} · {{ o.qty }} sh @ {{ o.priceLabel }}</span>
+          <span>{{ o.date }}</span>
+        </div>
+      </div>
+    }
+  </div>
+</div>
+}
+
+@if (screen() === 'account') {
+<div class="content">
+  <div class="header"><h1 class="large-title">Account</h1></div>
+  <div class="body">
+    <div class="account-profile">
+      <div class="avatar">JR</div>
+      <div><div class="account-name">Jamie Rivera</div><div class="muted-note">Account #4417-002</div></div>
+    </div>
+
+    <h3 class="group-title">Appearance</h3>
+    <div class="setting-row">
+      <div class="setting-row__label">Dark theme</div>
+      <button class="switch" [class.switch--on]="theme() === 'dark'" (click)="toggleTheme()"><span></span></button>
+    </div>
+
+    <h3 class="group-title">Notifications</h3>
+    @for (t of notifRows(); track t.key) {
+      <div class="setting-row">
+        <div class="setting-row__label">{{ t.label }}</div>
+        <button class="switch" [class.switch--on]="t.on" (click)="toggleNotif(t.key)"><span></span></button>
+      </div>
+    }
+
+    <h3 class="group-title">Security</h3>
+    <div class="setting-row">
+      <div class="setting-row__label">Two-factor authentication</div>
+      <button class="switch" [class.switch--on]="twoFactor()" (click)="toggleTwoFactor()"><span></span></button>
+    </div>
+    <button class="link-row">Change password</button>
+    <button class="link-row link-row--muted">Sign out</button>
+  </div>
+</div>
+}
+
+@if (showTabBar()) {
+<div class="tab-bar">
+  <button class="tab-item" [class.tab-item--active]="tabHomeActive()" (click)="goHome()">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l9-8 9 8"/><path d="M5 10v10h14V10"/></svg>
+    <span>Home</span>
+  </button>
+  <button class="tab-item" [class.tab-item--active]="screen() === 'portfolio'" (click)="goPortfolio()">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20V10M10 20V4M16 20v-7"/></svg>
+    <span>Portfolio</span>
+  </button>
+  <button class="tab-item" [class.tab-item--active]="screen() === 'orders'" (click)="goOrders()">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h2M9 6h11M4 12h2M9 12h11M4 18h2M9 18h11"/></svg>
+    <span>Orders</span>
+  </button>
+  <button class="tab-item" [class.tab-item--active]="screen() === 'account'" (click)="goAccount()">
+    <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 4-6 8-6s8 2 8 6"/></svg>
+    <span>Account</span>
+  </button>
+</div>
+}
+
+@if (ticketView(); as tv) {
+<div class="sheet-backdrop">
+<div class="sheet">
+<div class="sheet-handle"></div>
+
+@if (tv.step === 'ticket') {
+  <div class="sheet-header">
+    <h3 class="sheet-title">{{ tv.verb }} {{ tv.symbol }}</h3>
+    <button class="icon-btn" (click)="closeTicket()" aria-label="Close">&times;</button>
+  </div>
+  <div class="side-toggle">
+    <button class="side-btn" [class.side-btn--buy-active]="tv.side === 'buy'" (click)="updateTicket({ side: 'buy' })">Buy</button>
+    <button class="side-btn" [class.side-btn--sell-active]="tv.side === 'sell'" (click)="updateTicket({ side: 'sell' })">Sell</button>
+  </div>
+  <div class="ticket-fields">
+    <div>
+      <label class="field-label">Order type</label>
+      <select class="field-input" [ngModel]="tv.type" (ngModelChange)="updateTicket({ type: $event })">
+        <option value="market">Market</option>
+        <option value="limit">Limit</option>
+        <option value="stop">Stop</option>
+      </select>
+    </div>
+    <div>
+      <label class="field-label">Quantity (shares)</label>
+      <input type="number" min="1" class="field-input" [ngModel]="tv.qty" (ngModelChange)="updateTicket({ qty: $event })"/>
+    </div>
+    @if (tv.needsPrice) {
+      <div>
+        <label class="field-label">{{ tv.priceFieldLabel }}</label>
+        <input type="number" step="0.01" class="field-input" [ngModel]="tv.price" (ngModelChange)="updateTicket({ price: $event })"/>
+      </div>
+    }
+    <div class="est-row">
+      <span class="muted-note">Estimated total</span>
+      <span class="tabular">{{ tv.estLabel }}</span>
+    </div>
+  </div>
+  <button class="btn btn--primary btn--full" (click)="reviewTicket()">Review order</button>
+}
+
+@if (tv.step === 'confirm') {
+  <h3 class="sheet-title" style="margin-bottom:14px">Confirm order</h3>
+  <div class="confirm-rows">
+    <div class="confirm-row"><span class="muted-note">Symbol</span><span class="mono strong">{{ tv.symbol }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Side</span><span class="capitalize">{{ tv.side }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Type</span><span>{{ tv.typeLabel }}</span></div>
+    <div class="confirm-row"><span class="muted-note">Quantity</span><span class="tabular">{{ tv.qty }} shares</span></div>
+    <div class="confirm-row"><span class="muted-note">Price</span><span class="tabular">{{ tv.priceLabel }}</span></div>
+    <div class="confirm-row confirm-row--total"><span>Estimated total</span><span class="tabular">{{ tv.estLabel }}</span></div>
+  </div>
+  <div class="warning-box"><p>Orders fill at the prevailing market price. Once filled, this can't be undone.</p></div>
+  <div class="sheet-actions">
+    <button class="btn btn--secondary" (click)="backTicket()">Back</button>
+    <button class="btn btn--primary" (click)="placeOrder()">Place order</button>
+  </div>
+}
+
+@if (tv.step === 'success') {
+  <div class="success-block">
+    <div class="success-icon"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="var(--acme-color-success)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></div>
+    <h3 class="sheet-title">Order placed</h3>
+    <p class="muted-note">{{ tv.successSummary }}</p>
+    <p class="order-id">{{ tv.orderId }}</p>
+    <div class="sheet-actions sheet-actions--full">
+      <button class="btn btn--secondary" (click)="closeTicket()">Done</button>
+      <button class="btn btn--primary" (click)="goToOrders()">View orders</button>
+    </div>
+  </div>
+}
+
+</div>
+</div>
+}
+
+</div>
+</div>
+</div>

--- a/src/app/trading-app-mobile/trading-app-mobile.component.ts
+++ b/src/app/trading-app-mobile/trading-app-mobile.component.ts
@@ -4,32 +4,24 @@ import {
   ALLOC_COLORS, CATEGORIES, CATEGORY_SYMBOLS, CategoryId, NEWS_PUBLISHERS, Order, ORDER_HISTORY,
   HOLDINGS, RANGE_COUNTS, RANGE_IDS, RangeId, Side, STOCKS, TicketState, buildChart, fmtMoney, fmtNum,
   fmtPct, seededSeries
-} from './trading-data';
+} from '../trading-app/trading-data';
 
 type Theme = 'dark' | 'light';
-type Screen = 'dashboard' | 'portfolio' | 'orders' | 'account';
-
-const NAV: { id: Screen; label: string }[] = [
-  { id: 'dashboard', label: 'Dashboard' },
-  { id: 'portfolio', label: 'Portfolio' },
-  { id: 'orders', label: 'Orders' },
-  { id: 'account', label: 'Account' }
-];
+type Screen = 'home' | 'detail' | 'portfolio' | 'orders' | 'account';
 
 @Component({
-  selector: 'app-trading-app',
+  selector: 'app-trading-app-mobile',
   standalone: true,
   imports: [FormsModule],
-  templateUrl: './trading-app.component.html',
-  styleUrl: './trading-app.component.css'
+  templateUrl: './trading-app-mobile.component.html',
+  styleUrl: './trading-app-mobile.component.css'
 })
-export class TradingAppComponent {
-  readonly nav = NAV;
+export class TradingAppMobileComponent {
   readonly categories = CATEGORIES;
   readonly rangesIds = RANGE_IDS;
 
   theme = signal<Theme>((document.documentElement.getAttribute('data-theme') as Theme) || 'dark');
-  screen = signal<Screen>('dashboard');
+  screen = signal<Screen>('home');
   category = signal<CategoryId>('watch');
   activeSymbol = signal('AAPL');
   range = signal<RangeId>('1M');
@@ -45,9 +37,12 @@ export class TradingAppComponent {
     document.documentElement.setAttribute('data-theme', next);
     this.theme.set(next);
   }
-  setScreen(s: Screen) { this.screen.set(s); }
+  goHome() { this.screen.set('home'); }
+  goPortfolio() { this.screen.set('portfolio'); }
+  goOrders() { this.screen.set('orders'); }
+  goAccount() { this.screen.set('account'); }
   setCategory(c: CategoryId) { this.category.set(c); }
-  selectSymbol(sym: string) { this.activeSymbol.set(sym); this.searchQuery.set(''); }
+  selectSymbol(sym: string) { this.activeSymbol.set(sym); this.searchQuery.set(''); this.screen.set('detail'); }
   setRange(r: RangeId) { this.range.set(r); }
   toggleWatch(sym: string) {
     this.watchlist.update(list => list.includes(sym) ? list.filter(x => x !== sym) : [...list, sym]);
@@ -104,7 +99,7 @@ export class TradingAppComponent {
 
   readonly chart = computed(() => {
     const series = seededSeries(this.activeSymbol() + this.range(), this.stockData().price, RANGE_COUNTS[this.range()]);
-    return buildChart(series);
+    return buildChart(series, 360, 160);
   });
 
   readonly stats = computed(() => {
@@ -140,8 +135,7 @@ export class TradingAppComponent {
       const up = c >= 0;
       return {
         symbol: sym, name: d.name, priceLabel: fmtMoney(d.price),
-        changeLabel: fmtPct(d.chgPct), isUp: up, isDown: !up,
-        isActive: sym === this.activeSymbol()
+        changeLabel: fmtPct(d.chgPct), isUp: up, isDown: !up
       };
     });
   });
@@ -163,7 +157,7 @@ export class TradingAppComponent {
       const gain = value - cost;
       const up = gain >= 0;
       return {
-        symbol: h.symbol, shares: h.shares, avgCostLabel: fmtMoney(h.avgCost), priceLabel: fmtMoney(d.price),
+        symbol: h.symbol, shares: h.shares, avgCostLabel: fmtMoney(h.avgCost),
         valueLabel: fmtMoney(value), gainLabel: (up ? '+' : '') + fmtMoney(gain),
         isUp: up, isDown: !up
       };
@@ -171,26 +165,22 @@ export class TradingAppComponent {
   });
 
   readonly portfolio = computed(() => {
-    let totalValue = 0, totalCost = 0, dayChange = 0;
+    let totalValue = 0, totalCost = 0;
     HOLDINGS.forEach(h => {
       const d = STOCKS[h.symbol];
-      const value = h.shares * d.price;
-      totalValue += value;
+      totalValue += h.shares * d.price;
       totalCost += h.shares * h.avgCost;
-      dayChange += value * d.chgPct / 100;
     });
     const totalGain = totalValue - totalCost;
     const gainUp = totalGain >= 0;
-    const dayUp = dayChange >= 0;
     const allocation = HOLDINGS.map((h, i) => {
       const d = STOCKS[h.symbol];
       const value = h.shares * d.price;
       const pct = totalValue ? (value / totalValue) * 100 : 0;
-      return { symbol: h.symbol, pct, pctLabel: pct.toFixed(1) + '%', color: ALLOC_COLORS[i % ALLOC_COLORS.length] };
+      return { symbol: h.symbol, pct, color: ALLOC_COLORS[i % ALLOC_COLORS.length] };
     });
     return {
       totalLabel: fmtMoney(totalValue),
-      dayLabel: (dayUp ? '+' : '') + fmtMoney(dayChange), dayUp, dayDown: !dayUp,
       gainLabel: (gainUp ? '+' : '') + fmtMoney(totalGain), gainUp, gainDown: !gainUp,
       gainPctLabel: fmtPct(totalCost ? (totalGain / totalCost) * 100 : 0),
       allocation
@@ -199,16 +189,16 @@ export class TradingAppComponent {
 
   readonly orderRows = computed(() => this.orders().map(o => ({
     id: o.id, date: o.date, symbol: o.symbol, side: o.side, type: o.type, qty: o.qty,
-    priceLabel: fmtMoney(o.price), totalLabel: fmtMoney(o.qty * o.price),
+    priceLabel: fmtMoney(o.price),
     isFilled: o.status === 'filled', isPending: o.status === 'pending', isCanceled: o.status === 'canceled'
   })));
 
   readonly notifRows = computed(() => {
     const n = this.notif();
     return [
-      { key: 'price' as const, label: 'Price alerts', sub: 'Notify on watchlist price moves', on: n.price },
-      { key: 'fills' as const, label: 'Order fills', sub: 'Notify when an order fills', on: n.fills },
-      { key: 'news' as const, label: 'News digest', sub: 'Daily summary for your watchlist', on: n.news }
+      { key: 'price' as const, label: 'Price alerts', on: n.price },
+      { key: 'fills' as const, label: 'Order fills', on: n.fills },
+      { key: 'news' as const, label: 'News digest', on: n.news }
     ];
   });
 
@@ -238,4 +228,7 @@ export class TradingAppComponent {
         : ''
     };
   });
+
+  readonly showTabBar = computed(() => this.screen() !== 'detail');
+  readonly tabHomeActive = computed(() => this.screen() === 'home' || this.screen() === 'detail');
 }

--- a/src/app/trading-app/trading-data.ts
+++ b/src/app/trading-app/trading-data.ts
@@ -1,0 +1,158 @@
+export interface StockData {
+  name: string;
+  exch: string;
+  price: number;
+  chgPct: number;
+  open: number;
+  dayHigh: number;
+  dayLow: number;
+  wLow: number;
+  wHigh: number;
+  volume: number;
+  cap: string;
+}
+
+export interface Holding {
+  symbol: string;
+  shares: number;
+  avgCost: number;
+}
+
+export type Side = 'buy' | 'sell';
+export type OrderStatus = 'filled' | 'pending' | 'canceled';
+export type OrderType = 'market' | 'limit' | 'stop';
+export type CategoryId = 'watch' | 'stocks' | 'etfs' | 'crypto';
+export type RangeId = '1D' | '1W' | '1M' | '3M' | '1Y';
+export type TicketStep = 'ticket' | 'confirm' | 'success';
+
+export interface Order {
+  id: string;
+  date: string;
+  symbol: string;
+  side: Side;
+  type: string;
+  qty: number;
+  price: number;
+  status: OrderStatus;
+}
+
+export interface TicketState {
+  symbol: string;
+  side: Side;
+  type: OrderType;
+  qty: string;
+  price: string;
+  step: TicketStep;
+  id?: string;
+  status?: OrderStatus;
+}
+
+export interface ChartGeometry {
+  path: string;
+  areaPath: string;
+  rising: boolean;
+  falling: boolean;
+}
+
+export const CATEGORY_SYMBOLS: Record<Exclude<CategoryId, 'watch'>, string[]> = {
+  stocks: ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN', 'META', 'TSLA', 'JPM', 'NFLX', 'AMD'],
+  etfs: ['SPY', 'QQQ', 'VTI'],
+  crypto: ['BTC-USD', 'ETH-USD']
+};
+
+export const STOCKS: Record<string, StockData> = {
+  AAPL: { name: 'Apple Inc.', exch: 'NASDAQ', price: 231.52, chgPct: 1.82, open: 228.10, dayHigh: 232.40, dayLow: 227.55, wLow: 164.08, wHigh: 237.23, volume: 58230000, cap: '3.58T' },
+  MSFT: { name: 'Microsoft Corporation', exch: 'NASDAQ', price: 468.20, chgPct: 0.64, open: 465.80, dayHigh: 470.10, dayLow: 464.20, wLow: 385.58, wHigh: 480.00, volume: 19850000, cap: '3.48T' },
+  NVDA: { name: 'NVIDIA Corporation', exch: 'NASDAQ', price: 142.85, chgPct: -1.24, open: 144.90, dayHigh: 145.60, dayLow: 141.90, wLow: 86.62, wHigh: 153.13, volume: 210450000, cap: '3.49T' },
+  GOOGL: { name: 'Alphabet Inc.', exch: 'NASDAQ', price: 191.40, chgPct: 2.05, open: 187.60, dayHigh: 192.80, dayLow: 187.10, wLow: 140.53, wHigh: 195.50, volume: 27340000, cap: '2.35T' },
+  AMZN: { name: 'Amazon.com, Inc.', exch: 'NASDAQ', price: 214.30, chgPct: 0.91, open: 212.50, dayHigh: 215.90, dayLow: 211.80, wLow: 151.61, wHigh: 220.53, volume: 34120000, cap: '2.27T' },
+  META: { name: 'Meta Platforms, Inc.', exch: 'NASDAQ', price: 612.75, chgPct: 1.14, open: 605.90, dayHigh: 615.20, dayLow: 604.10, wLow: 414.50, wHigh: 638.40, volume: 12870000, cap: '1.55T' },
+  TSLA: { name: 'Tesla, Inc.', exch: 'NASDAQ', price: 268.90, chgPct: -3.37, open: 279.40, dayHigh: 281.00, dayLow: 267.55, wLow: 138.80, wHigh: 488.54, volume: 98450000, cap: '860.2B' },
+  JPM: { name: 'JPMorgan Chase & Co.', exch: 'NYSE', price: 231.10, chgPct: 0.28, open: 230.30, dayHigh: 232.60, dayLow: 229.40, wLow: 179.20, wHigh: 245.10, volume: 8320000, cap: '650.4B' },
+  NFLX: { name: 'Netflix, Inc.', exch: 'NASDAQ', price: 985.40, chgPct: -0.52, open: 990.10, dayHigh: 995.80, dayLow: 981.20, wLow: 585.28, wHigh: 1064.50, volume: 2140000, cap: '425.1B' },
+  AMD: { name: 'Advanced Micro Devices', exch: 'NASDAQ', price: 168.20, chgPct: 2.71, open: 163.80, dayHigh: 169.40, dayLow: 163.10, wLow: 93.12, wHigh: 187.28, volume: 45230000, cap: '272.6B' },
+  SPY: { name: 'SPDR S&P 500 ETF Trust', exch: 'NYSEARCA', price: 612.34, chgPct: 0.42, open: 609.80, dayHigh: 613.50, dayLow: 608.90, wLow: 493.05, wHigh: 618.30, volume: 62340000, cap: '—' },
+  QQQ: { name: 'Invesco QQQ Trust', exch: 'NASDAQ', price: 524.18, chgPct: 0.58, open: 521.30, dayHigh: 526.00, dayLow: 520.60, wLow: 402.39, wHigh: 530.20, volume: 41230000, cap: '—' },
+  VTI: { name: 'Vanguard Total Stock Market ETF', exch: 'NYSEARCA', price: 312.66, chgPct: 0.39, open: 311.20, dayHigh: 313.50, dayLow: 310.80, wLow: 246.05, wHigh: 315.90, volume: 3120000, cap: '—' },
+  'BTC-USD': { name: 'Bitcoin', exch: 'Crypto', price: 118420.00, chgPct: 2.15, open: 115900, dayHigh: 119800, dayLow: 114600, wLow: 52150, wHigh: 124500, volume: 0, cap: '2.35T' },
+  'ETH-USD': { name: 'Ethereum', exch: 'Crypto', price: 4380.50, chgPct: -1.05, open: 4428.00, dayHigh: 4455.00, dayLow: 4350.00, wLow: 1890.40, wHigh: 4820.00, volume: 0, cap: '528.4B' }
+};
+
+export const HOLDINGS: Holding[] = [
+  { symbol: 'AAPL', shares: 40, avgCost: 189.40 },
+  { symbol: 'MSFT', shares: 15, avgCost: 365.20 },
+  { symbol: 'NVDA', shares: 60, avgCost: 98.75 },
+  { symbol: 'TSLA', shares: 20, avgCost: 240.60 },
+  { symbol: 'GOOGL', shares: 25, avgCost: 150.30 },
+  { symbol: 'QQQ', shares: 30, avgCost: 480.10 }
+];
+
+export const ORDER_HISTORY: Order[] = [
+  { id: 'ORD-10482', date: 'Jul 16, 2026', symbol: 'AAPL', side: 'buy', type: 'Market', qty: 10, price: 229.80, status: 'filled' },
+  { id: 'ORD-10475', date: 'Jul 15, 2026', symbol: 'TSLA', side: 'sell', type: 'Limit', qty: 5, price: 275.00, status: 'filled' },
+  { id: 'ORD-10461', date: 'Jul 14, 2026', symbol: 'NVDA', side: 'buy', type: 'Limit', qty: 20, price: 140.00, status: 'pending' },
+  { id: 'ORD-10450', date: 'Jul 12, 2026', symbol: 'MSFT', side: 'buy', type: 'Market', qty: 8, price: 462.10, status: 'filled' },
+  { id: 'ORD-10439', date: 'Jul 10, 2026', symbol: 'GOOGL', side: 'sell', type: 'Stop', qty: 12, price: 182.50, status: 'canceled' },
+  { id: 'ORD-10422', date: 'Jul 8, 2026', symbol: 'AMD', side: 'buy', type: 'Market', qty: 25, price: 159.40, status: 'filled' },
+  { id: 'ORD-10410', date: 'Jul 6, 2026', symbol: 'QQQ', side: 'buy', type: 'Market', qty: 15, price: 518.30, status: 'filled' },
+  { id: 'ORD-10398', date: 'Jul 3, 2026', symbol: 'META', side: 'sell', type: 'Limit', qty: 4, price: 625.00, status: 'pending' }
+];
+
+export const CATEGORIES: { id: CategoryId; label: string }[] = [
+  { id: 'watch', label: 'Watch' },
+  { id: 'stocks', label: 'Stocks' },
+  { id: 'etfs', label: 'ETFs' },
+  { id: 'crypto', label: 'Crypto' }
+];
+
+export const RANGE_COUNTS: Record<RangeId, number> = { '1D': 24, '1W': 28, '1M': 30, '3M': 45, '1Y': 52 };
+export const RANGE_IDS: RangeId[] = ['1D', '1W', '1M', '3M', '1Y'];
+export const ALLOC_COLORS = ['#2563EB', '#3b7bf0', '#5c93f4', '#7ba9f7', '#9cbff9', '#bdd5fc'];
+export const NEWS_PUBLISHERS = ['Market Wire', 'Ticker Daily', 'Desk Notes'];
+
+export function fmtMoney(v: number | null | undefined): string {
+  if (v == null || isNaN(v)) return '—';
+  return '$' + v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+export function fmtPct(v: number): string {
+  const sign = v >= 0 ? '+' : '';
+  return sign + v.toFixed(2) + '%';
+}
+export function fmtNum(v: number): string {
+  if (!v) return '—';
+  if (v >= 1e9) return (v / 1e9).toFixed(2) + 'B';
+  if (v >= 1e6) return (v / 1e6).toFixed(2) + 'M';
+  if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+  return String(v);
+}
+export function seededSeries(seedStr: string, base: number, count: number): number[] {
+  let h = 0;
+  for (let i = 0; i < seedStr.length; i++) h = (h * 31 + seedStr.charCodeAt(i)) | 0;
+  function rnd() {
+    h ^= h << 13; h ^= h >>> 17; h ^= h << 5;
+    return ((h >>> 0) % 1000) / 1000;
+  }
+  let v = base * 0.9;
+  const pts: number[] = [];
+  for (let i = 0; i < count; i++) {
+    v += (rnd() - 0.47) * base * 0.018;
+    v = Math.max(base * 0.75, Math.min(base * 1.15, v));
+    pts.push(v);
+  }
+  pts[pts.length - 1] = base;
+  return pts;
+}
+export function buildChart(points: number[], width = 800, height = 220): ChartGeometry {
+  const padTop = height >= 200 ? 16 : 10, padBottom = height >= 200 ? 16 : 10;
+  const min = Math.min(...points), max = Math.max(...points), span = (max - min) || 1;
+  const innerH = height - padTop - padBottom;
+  const xy = points.map((p, i) => {
+    const x = (i / (points.length - 1)) * width;
+    const y = padTop + innerH - ((p - min) / span) * innerH;
+    return { x, y };
+  });
+  const path = xy.map((pt, i) => (i === 0 ? 'M' : 'L') + pt.x.toFixed(2) + ',' + pt.y.toFixed(2)).join(' ');
+  const areaPath = path + ' L' + xy[xy.length - 1].x.toFixed(2) + ',' + (height - padBottom) + ' L' + xy[0].x.toFixed(2) + ',' + (height - padBottom) + ' Z';
+  const rising = points[points.length - 1] >= points[0];
+  return { path, areaPath, rising, falling: !rising };
+}


### PR DESCRIPTION
## Summary
- Imports "Stock Trading App Mobile.dc.html" from the same Claude Design project as the desktop trading app (`015d46d8-065a-48b7-a81c-052820fa56b9`), along with its `ios-frame.jsx` reference, and implements it as `TradingAppMobileComponent` at `/trading-mobile`.
- Wraps the screen content in a hand-built iPhone frame (dynamic island, status bar, rounded bezel) reimplemented in plain CSS, since `ios-frame.jsx` is a JSX presentational helper from the design tool and isn't directly importable into Angular.
- Covers the mobile screens from the design: **Home** (watchlist + search/categories), **Detail** (full-screen stock view reached by tapping a symbol — chart, stats, news, buy/sell action bar), **Portfolio**, **Orders**, **Account**, a bottom tab bar (hidden on the detail screen per the design), and the buy/sell bottom-sheet ticket flow (ticket → confirm → success).
- Extracts the mock data and helpers shared by the desktop and mobile designs (`STOCKS`, `HOLDINGS`, `ORDER_HISTORY`, formatters, chart geometry) into `src/app/trading-app/trading-data.ts` so neither component duplicates it, and updates the existing desktop `TradingAppComponent` to import from there instead.

## Test plan
- [x] `ng build` compiles cleanly
- [x] Verified `/trading-mobile` serves correctly via the dev server, and the bundled JS passes a syntax check
- [ ] Manual visual check in a real browser — no working Chrome binary was available in this environment's architecture to capture a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)