### PR TITLE
Bump actions/setup-java and github/codeql-action to latest SHA pins

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
 
       - name: Set up JDK 21
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -71,6 +71,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Re-checked all npm dependencies and GitHub Actions pins for newer releases.
- npm packages are already at their latest pinnable exact versions — no changes needed (`typescript` stays at `6.0.3` since Angular 22's `@angular/compiler-cli` and `@angular-devkit/build-angular` require `typescript: >=6.0 <6.1`).
- Bumped `actions/setup-java` from `v5.5.0` to `v5.6.0` in `android.yaml`.
- Bumped `github/codeql-action` (`init`/`analyze`/`upload-sarif`) from `v4.37.0` to `v4.37.1` in `codeql.yml` and `scorecard.yml`.
- Verified the Docker base images (`node:alpine` in `dockerfile`, `javascript-node:dev-22-bullseye` in `.devcontainer/Dockerfile`) already match their current upstream digests — no change needed.
- All other SHA-pinned actions (`checkout`, `setup-node`, `upload/download-artifact`, `azure/login`, `azure/webapps-deploy`, `android-actions/setup-android`, `ossf/scorecard-action`) were already on their latest release.

## Test plan
- [x] `ng build` succeeds
- [x] Verified each updated action's tag/SHA against the GitHub API directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)