### PR TITLE
Update GitHub Actions to latest SHA and fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,23 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
     schedule:
       interval: "weekly"
 

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 

--- a/.github/workflows/master_angular.yml
+++ b/.github/workflows/master_angular.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24.x'
 


### PR DESCRIPTION
## Summary
- Audited npm dependencies, Docker base images, and GitHub Actions for updates — npm packages and Docker images were already at the latest versions permitted by their constraints and were already pinned (lockfile integrity hashes / image digests).
- Bumped `actions/setup-node` from `v6.4.0` to `v7.0.0` (SHA `820762786026740c76f36085b0efc47a31fe5020`) across `android.yaml`, `build.yaml`, and `master_angular.yml`. Reviewed the release notes — no breaking changes affecting these workflows.
- Fixed `.github/dependabot.yml`, which had an invalid empty `package-ecosystem: ""` (fails schema validation), replacing it with proper `npm`, `github-actions`, and `docker` (root + `.devcontainer`) entries so future dependency drift is tracked automatically.

## Test plan
- [x] Validated all edited YAML files parse correctly
- [x] Verified `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020` resolves to tag `v7.0.0` via `git ls-remote`
- [x] Confirmed no other workflow actions have newer releases available
- [x] Confirmed npm packages and Docker image digests are already current

🤖 Generated with [Claude Code](https://claude.com/claude-code)