### PR TITLE
Add unit tests for full function coverage across the app

### DIFF
--- a/src/app/stock.service.spec.ts
+++ b/src/app/stock.service.spec.ts
@@ -1,0 +1,275 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { StockService } from './stock.service';
+
+describe('StockService', () => {
+  let service: StockService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    });
+    service = TestBed.inject(StockService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('search', () => {
+    it('sends the query with quotesCount/newsCount params to the search endpoint', () => {
+      service.search('AAPL').subscribe();
+      const req = httpMock.expectOne(
+        r => r.url === '/api/yf-search' && r.params.get('q') === 'AAPL'
+      );
+      expect(req.request.params.get('quotesCount')).toBe('8');
+      expect(req.request.params.get('newsCount')).toBe('0');
+      req.flush({ quotes: [] });
+    });
+
+    it('maps and filters quotes to supported quote types', () => {
+      let result: any[] = [];
+      service.search('AAPL').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-search');
+      req.flush({
+        quotes: [
+          { symbol: 'AAPL', shortname: 'Apple', exchDisp: 'NASDAQ', quoteType: 'EQUITY' },
+          { symbol: 'QQQ', longname: 'Invesco QQQ', quoteType: 'ETF' },
+          { symbol: '^GSPC', quoteType: 'INDEX' },
+          { symbol: 'BTC-USD', quoteType: 'CRYPTOCURRENCY' },
+          { symbol: 'FUTURE', quoteType: 'FUTURE' }, // unsupported type, filtered out
+          { shortname: 'No symbol', quoteType: 'EQUITY' } // no symbol, filtered out
+        ]
+      });
+      expect(result.length).toBe(4);
+      expect(result.map(r => r.symbol)).toEqual(['AAPL', 'QQQ', '^GSPC', 'BTC-USD']);
+      expect(result[0]).toEqual({
+        symbol: 'AAPL', shortname: 'Apple', longname: undefined, exchange: 'NASDAQ', quoteType: 'EQUITY'
+      });
+    });
+
+    it('falls back to the symbol for shortname and empty string for exchange', () => {
+      let result: any[] = [];
+      service.search('QQQ').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-search');
+      req.flush({ quotes: [{ symbol: 'QQQ', quoteType: 'ETF' }] });
+      expect(result[0].shortname).toBe('QQQ');
+      expect(result[0].exchange).toBe('');
+    });
+
+    it('returns an empty array when the response has no quotes field', () => {
+      let result: any[] | undefined;
+      service.search('zzz').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-search');
+      req.flush({});
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getNews', () => {
+    it('sends the symbol with quotesCount=0/newsCount=8 to the search endpoint', () => {
+      service.getNews('AAPL').subscribe();
+      const req = httpMock.expectOne(
+        r => r.url === '/api/yf-search' && r.params.get('q') === 'AAPL'
+      );
+      expect(req.request.params.get('quotesCount')).toBe('0');
+      expect(req.request.params.get('newsCount')).toBe('8');
+      req.flush({ news: [] });
+    });
+
+    it('maps news items and defaults missing fields', () => {
+      let result: any[] = [];
+      service.getNews('AAPL').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-search');
+      req.flush({
+        news: [
+          { uuid: 'u1', title: 'Title', publisher: 'Pub', link: 'https://x', providerPublishTime: 123 },
+          {}
+        ]
+      });
+      expect(result[0]).toEqual({ uuid: 'u1', title: 'Title', publisher: 'Pub', link: 'https://x', providerPublishTime: 123 });
+      expect(result[1]).toEqual({ uuid: '', title: '', publisher: '', link: '', providerPublishTime: 0 });
+    });
+
+    it('returns an empty array when the response has no news field', () => {
+      let result: any[] | undefined;
+      service.getNews('AAPL').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-search');
+      req.flush({});
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getQuote', () => {
+    it('hits the chart endpoint for the symbol with interval=1d&range=5d', () => {
+      service.getQuote('AAPL').subscribe();
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+      expect(req.request.params.get('interval')).toBe('1d');
+      expect(req.request.params.get('range')).toBe('5d');
+      req.flush({ chart: { result: [{ meta: { regularMarketPrice: 1 } }] } });
+    });
+
+    it('URL-encodes symbols containing special characters', () => {
+      service.getQuote('BRK/B').subscribe();
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/BRK%2FB');
+      req.flush({ chart: { result: [{ meta: { regularMarketPrice: 1 } }] } });
+      expect(req.request.url).toContain('BRK%2FB');
+    });
+
+    it('computes change and changePercent from price vs. previous close', () => {
+      let result: any;
+      service.getQuote('AAPL').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+      req.flush({
+        chart: {
+          result: [{
+            meta: {
+              symbol: 'AAPL',
+              longName: 'Apple Inc.',
+              fullExchangeName: 'NASDAQ',
+              currency: 'USD',
+              regularMarketPrice: 110,
+              chartPreviousClose: 100,
+              regularMarketOpen: 101,
+              regularMarketDayHigh: 112,
+              regularMarketDayLow: 99,
+              fiftyTwoWeekHigh: 150,
+              fiftyTwoWeekLow: 80,
+              regularMarketVolume: 5000,
+              marketState: 'REGULAR',
+              regularMarketTime: 1700000000
+            }
+          }]
+        }
+      });
+      expect(result.price).toBe(110);
+      expect(result.previousClose).toBe(100);
+      expect(result.change).toBe(10);
+      expect(result.changePercent).toBe(10);
+      expect(result.name).toBe('Apple Inc.');
+      expect(result.exchange).toBe('NASDAQ');
+    });
+
+    it('falls back to previousClose, then to price, when chartPreviousClose is absent', () => {
+      let result: any;
+      service.getQuote('AAPL').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+      req.flush({ chart: { result: [{ meta: { previousClose: 90, regularMarketPrice: 100 } }] } });
+      expect(result.previousClose).toBe(90);
+      expect(result.change).toBe(10);
+    });
+
+    it('yields changePercent 0 when there is no previous close to divide by', () => {
+      let result: any;
+      service.getQuote('NEW').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/NEW');
+      // no previousClose/chartPreviousClose and price defaults to 0 -> previousClose falls back to price (0)
+      req.flush({ chart: { result: [{ meta: {} }] } });
+      expect(result.price).toBe(0);
+      expect(result.previousClose).toBe(0);
+      expect(result.changePercent).toBe(0);
+    });
+
+    it('falls back symbol/name to the requested symbol when meta omits them', () => {
+      let result: any;
+      service.getQuote('XYZ').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/XYZ');
+      req.flush({ chart: { result: [{ meta: {} }] } });
+      expect(result.symbol).toBe('XYZ');
+      expect(result.name).toBe('XYZ');
+      expect(result.currency).toBe('USD');
+    });
+
+    it('errors when the response has no chart result', done => {
+      service.getQuote('MISSING').subscribe({
+        next: () => fail('expected an error'),
+        error: err => {
+          expect(err.message).toBe('No data for symbol');
+          done();
+        }
+      });
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/MISSING');
+      req.flush({ chart: { result: [] } });
+    });
+  });
+
+  describe('getHistory', () => {
+    const rangeIntervals: Record<string, string> = {
+      '1d': '5m', '5d': '30m', '1mo': '1d', '6mo': '1d', '1y': '1wk', '5y': '1mo'
+    };
+
+    it('maps each supported range to its documented interval', () => {
+      for (const [range, interval] of Object.entries(rangeIntervals)) {
+        service.getHistory('AAPL', range as any).subscribe();
+        const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+        expect(req.request.params.get('interval')).withContext(range).toBe(interval);
+        expect(req.request.params.get('range')).toBe(range);
+        req.flush({ chart: { result: [{ meta: {}, timestamp: [], indicators: { quote: [{ close: [] }] } }] } });
+      }
+    });
+
+    it('zips timestamps with closes, converting seconds to milliseconds', () => {
+      let result: any;
+      service.getHistory('AAPL', '1mo').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+      req.flush({
+        chart: {
+          result: [{
+            meta: { symbol: 'AAPL', currency: 'USD' },
+            timestamp: [1000, 2000, 3000],
+            indicators: { quote: [{ close: [10, 11, 12] }] }
+          }]
+        }
+      });
+      expect(result.points).toEqual([
+        { time: 1000000, close: 10 },
+        { time: 2000000, close: 11 },
+        { time: 3000000, close: 12 }
+      ]);
+    });
+
+    it('skips points whose close is null, undefined, or NaN', () => {
+      let result: any;
+      service.getHistory('AAPL', '1mo').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/AAPL');
+      req.flush({
+        chart: {
+          result: [{
+            meta: {},
+            timestamp: [1, 2, 3, 4],
+            indicators: { quote: [{ close: [10, null, NaN, 13] }] }
+          }]
+        }
+      });
+      expect(result.points).toEqual([
+        { time: 1000, close: 10 },
+        { time: 4000, close: 13 }
+      ]);
+    });
+
+    it('defaults currency to USD and falls back symbol to the requested symbol', () => {
+      let result: any;
+      service.getHistory('ZZZ', '1y').subscribe(r => (result = r));
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/ZZZ');
+      req.flush({ chart: { result: [{ meta: {}, timestamp: [], indicators: { quote: [{ close: [] }] } }] } });
+      expect(result.symbol).toBe('ZZZ');
+      expect(result.currency).toBe('USD');
+      expect(result.points).toEqual([]);
+    });
+
+    it('errors when the response has no chart result', done => {
+      service.getHistory('MISSING', '1d').subscribe({
+        next: () => fail('expected an error'),
+        error: err => {
+          expect(err.message).toBe('No data for symbol');
+          done();
+        }
+      });
+      const req = httpMock.expectOne(r => r.url === '/api/yf-chart/MISSING');
+      req.flush({ chart: { result: [] } });
+    });
+  });
+});

--- a/src/app/stock/stock.component.spec.ts
+++ b/src/app/stock/stock.component.spec.ts
@@ -1,0 +1,596 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { StockComponent } from './stock.component';
+import { StockService, Quote, NewsItem, History, SymbolMatch } from '../stock.service';
+
+function makeQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    exchange: 'NASDAQ',
+    currency: 'USD',
+    price: 231.52,
+    previousClose: 227.4,
+    change: 4.12,
+    changePercent: 1.81,
+    open: 228.1,
+    dayHigh: 232.4,
+    dayLow: 227.55,
+    fiftyTwoWeekHigh: 237.23,
+    fiftyTwoWeekLow: 164.08,
+    volume: 58230000,
+    marketState: 'REGULAR',
+    regularMarketTime: 1700000000,
+    ...overrides
+  };
+}
+
+describe('StockComponent', () => {
+  let fixture: ComponentFixture<StockComponent>;
+  let component: StockComponent;
+  let stocks: jasmine.SpyObj<StockService>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+
+    stocks = jasmine.createSpyObj<StockService>('StockService', ['search', 'getNews', 'getQuote', 'getHistory']);
+    stocks.search.and.returnValue(of([]));
+    stocks.getNews.and.returnValue(of([]));
+    stocks.getQuote.and.returnValue(of(makeQuote()));
+    stocks.getHistory.and.returnValue(of({ symbol: 'AAPL', currency: 'USD', points: [] } as History));
+
+    TestBed.configureTestingModule({
+      imports: [StockComponent],
+      providers: [{ provide: StockService, useValue: stocks }]
+    });
+
+    fixture = TestBed.createComponent(StockComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('creates the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('bootstraps dark theme by default', () => {
+      fixture.detectChanges();
+      expect(component.theme()).toBe('dark');
+    });
+
+    it('bootstraps light theme when data-theme="light" is already set', () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      fixture.detectChanges();
+      expect(component.theme()).toBe('light');
+    });
+
+    it('loads the default symbol (AAPL) on init', () => {
+      fixture.detectChanges();
+      expect(stocks.getQuote).toHaveBeenCalledWith('AAPL');
+      expect(stocks.getHistory).toHaveBeenCalledWith('AAPL', '1mo');
+      expect(stocks.getNews).toHaveBeenCalledWith('AAPL');
+    });
+
+    it('seeds the watch category from the default watchlist when localStorage is empty', () => {
+      fixture.detectChanges();
+      expect(component.rows().map(r => r.symbol)).toEqual(['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'TSLA']);
+    });
+  });
+
+  describe('toggleTheme', () => {
+    it('flips dark -> light and persists it', () => {
+      fixture.detectChanges();
+      component.toggleTheme();
+      expect(component.theme()).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(localStorage.getItem('stockwatch.theme')).toBe('light');
+    });
+
+    it('flips light -> dark', () => {
+      fixture.detectChanges();
+      component.toggleTheme();
+      component.toggleTheme();
+      expect(component.theme()).toBe('dark');
+    });
+
+    it('updates the color-scheme meta tag when present', () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'color-scheme');
+      document.head.appendChild(meta);
+      fixture.detectChanges();
+      component.toggleTheme();
+      expect(meta.content).toBe('light');
+      meta.remove();
+    });
+
+    it('does not throw when localStorage.setItem fails', () => {
+      fixture.detectChanges();
+      spyOn(localStorage, 'setItem').and.throwError('quota exceeded');
+      expect(() => component.toggleTheme()).not.toThrow();
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('completes destroy$ and unsubscribes the category subscription without throwing', () => {
+      fixture.detectChanges();
+      component.setCategory('stocks');
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
+  });
+
+  describe('search', () => {
+    it('debounces input and calls StockService.search after 250ms', fakeAsync(() => {
+      fixture.detectChanges();
+      stocks.search.and.returnValue(of([{ symbol: 'AAPL', shortname: 'Apple', exchange: 'NASDAQ', quoteType: 'EQUITY' } as SymbolMatch]));
+      component.searchQuery = 'aap';
+      component.onSearchInput();
+      tick(249);
+      expect(stocks.search).not.toHaveBeenCalled();
+      tick(1);
+      expect(stocks.search).toHaveBeenCalledWith('aap');
+      expect(component.searchResults.length).toBe(1);
+      expect(component.showResults).toBeTrue();
+    }));
+
+    it('does not call the search API for an empty/whitespace query', fakeAsync(() => {
+      fixture.detectChanges();
+      component.searchQuery = '   ';
+      component.onSearchInput();
+      tick(300);
+      expect(stocks.search).not.toHaveBeenCalled();
+      expect(component.searchResults).toEqual([]);
+    }));
+
+    it('clears results and hides the panel when the search call errors', fakeAsync(() => {
+      fixture.detectChanges();
+      stocks.search.and.returnValue(throwError(() => new Error('network')));
+      component.searchQuery = 'zzz';
+      component.onSearchInput();
+      tick(300);
+      expect(component.searchResults).toEqual([]);
+      expect(component.showResults).toBeFalse();
+    }));
+
+    it('distinctUntilChanged suppresses a repeated identical query', fakeAsync(() => {
+      fixture.detectChanges();
+      component.searchQuery = 'aapl';
+      component.onSearchInput();
+      tick(300);
+      const callsAfterFirst = stocks.search.calls.count();
+      component.searchQuery = 'aapl';
+      component.onSearchInput();
+      tick(300);
+      expect(stocks.search.calls.count()).toBe(callsAfterFirst);
+    }));
+
+    it('onSearchFocus reopens the panel when there are existing results', () => {
+      fixture.detectChanges();
+      component.searchResults = [{ symbol: 'AAPL', shortname: 'Apple', exchange: 'NASDAQ', quoteType: 'EQUITY' }];
+      component.showResults = false;
+      component.onSearchFocus();
+      expect(component.showResults).toBeTrue();
+    });
+
+    it('onSearchFocus is a no-op when there are no results', () => {
+      fixture.detectChanges();
+      component.searchResults = [];
+      component.showResults = false;
+      component.onSearchFocus();
+      expect(component.showResults).toBeFalse();
+    });
+
+    it('onSearchBlur hides the panel after a short delay', fakeAsync(() => {
+      fixture.detectChanges();
+      component.showResults = true;
+      component.onSearchBlur();
+      expect(component.showResults).toBeTrue();
+      tick(150);
+      expect(component.showResults).toBeFalse();
+    }));
+
+    it('selectMatch clears the query/results and loads the chosen symbol', () => {
+      fixture.detectChanges();
+      stocks.getQuote.calls.reset();
+      component.searchQuery = 'msf';
+      component.searchResults = [{ symbol: 'MSFT', shortname: 'Microsoft', exchange: 'NASDAQ', quoteType: 'EQUITY' }];
+      component.showResults = true;
+      component.selectMatch(component.searchResults[0]);
+      expect(component.searchQuery).toBe('');
+      expect(component.searchResults).toEqual([]);
+      expect(component.showResults).toBeFalse();
+      expect(stocks.getQuote).toHaveBeenCalledWith('MSFT');
+    });
+  });
+
+  describe('selectSymbol', () => {
+    it('populates quote/history/news on success', () => {
+      const quote = makeQuote({ symbol: 'MSFT' });
+      const news: NewsItem[] = [{ uuid: 'u', title: 't', publisher: 'p', link: 'l', providerPublishTime: 1 }];
+      const history: History = { symbol: 'MSFT', currency: 'USD', points: [{ time: 1, close: 2 }] };
+      stocks.getQuote.and.returnValue(of(quote));
+      stocks.getNews.and.returnValue(of(news));
+      stocks.getHistory.and.returnValue(of(history));
+
+      fixture.detectChanges();
+      component.selectSymbol('MSFT');
+
+      expect(component.quote()).toEqual(quote);
+      expect(component.news()).toEqual(news);
+      expect(component.history()).toEqual(history);
+      expect(component.loadingQuote()).toBeFalse();
+      expect(component.loadingHistory()).toBeFalse();
+      expect(component.loadingNews()).toBeFalse();
+      expect(component.error()).toBe('');
+    });
+
+    it('sets an error and clears the quote when getQuote fails', () => {
+      stocks.getQuote.and.returnValue(throwError(() => new Error('boom')));
+      fixture.detectChanges();
+      component.selectSymbol('BADSYM');
+      expect(component.error()).toBe('Could not load quote for "BADSYM".');
+      expect(component.quote()).toBeNull();
+      expect(component.loadingQuote()).toBeFalse();
+    });
+
+    it('clears history and stops the loading flag when getHistory fails', () => {
+      stocks.getHistory.and.returnValue(throwError(() => new Error('boom')));
+      fixture.detectChanges();
+      component.selectSymbol('AAPL');
+      expect(component.history()).toBeNull();
+      expect(component.loadingHistory()).toBeFalse();
+    });
+
+    it('clears news and stops the loading flag when getNews fails', () => {
+      stocks.getNews.and.returnValue(throwError(() => new Error('boom')));
+      fixture.detectChanges();
+      component.selectSymbol('AAPL');
+      expect(component.news()).toEqual([]);
+      expect(component.loadingNews()).toBeFalse();
+    });
+  });
+
+  describe('setRange', () => {
+    it('is a no-op when re-selecting the current range', () => {
+      fixture.detectChanges();
+      stocks.getHistory.calls.reset();
+      component.setRange('1mo');
+      expect(stocks.getHistory).not.toHaveBeenCalled();
+    });
+
+    it('reloads history for the active symbol on a new range', () => {
+      fixture.detectChanges();
+      stocks.getHistory.calls.reset();
+      component.setRange('1y');
+      expect(component.range()).toBe('1y');
+      expect(stocks.getHistory).toHaveBeenCalledWith('AAPL', '1y');
+    });
+
+    it('does not call getHistory when there is no active quote symbol', () => {
+      fixture.detectChanges();
+      component.quote.set(null);
+      stocks.getHistory.calls.reset();
+      component.setRange('5d');
+      expect(stocks.getHistory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onCatTabKeydown', () => {
+    function keyEvent(key: string): KeyboardEvent {
+      return new KeyboardEvent('keydown', { key });
+    }
+
+    it('ArrowRight moves to the next category and wraps at the end', () => {
+      fixture.detectChanges();
+      const ev = keyEvent('ArrowRight');
+      spyOn(ev, 'preventDefault');
+      component.onCatTabKeydown(ev, 'commodities'); // last category -> wraps to first
+      expect(ev.preventDefault).toHaveBeenCalled();
+      expect(component.activeCategory()).toBe('watch');
+    });
+
+    it('ArrowLeft moves to the previous category and wraps at the start', () => {
+      fixture.detectChanges();
+      component.onCatTabKeydown(keyEvent('ArrowLeft'), 'watch');
+      expect(component.activeCategory()).toBe('commodities');
+    });
+
+    it('Home jumps to the first category', () => {
+      fixture.detectChanges();
+      component.onCatTabKeydown(keyEvent('Home'), 'crypto');
+      expect(component.activeCategory()).toBe('watch');
+    });
+
+    it('End jumps to the last category', () => {
+      fixture.detectChanges();
+      component.onCatTabKeydown(keyEvent('End'), 'watch');
+      expect(component.activeCategory()).toBe('commodities');
+    });
+
+    it('ignores unrelated keys and does not call preventDefault', () => {
+      fixture.detectChanges();
+      const ev = keyEvent('Tab');
+      spyOn(ev, 'preventDefault');
+      component.onCatTabKeydown(ev, 'watch');
+      expect(ev.preventDefault).not.toHaveBeenCalled();
+      expect(component.activeCategory()).toBe('watch');
+    });
+  });
+
+  describe('categories', () => {
+    it('setCategory is a no-op when re-selecting the active category', () => {
+      fixture.detectChanges();
+      stocks.getQuote.calls.reset();
+      component.setCategory('watch');
+      expect(stocks.getQuote).not.toHaveBeenCalled();
+    });
+
+    it('setCategory switches category and loads quotes for its symbols', () => {
+      fixture.detectChanges();
+      stocks.getQuote.and.returnValue(of(makeQuote({ symbol: 'SPY', name: 'SPDR S&P 500', price: 612, changePercent: 0.4 })));
+      component.setCategory('etfs');
+      expect(component.activeCategory()).toBe('etfs');
+      expect(component.rows().length).toBe(10);
+      expect(component.rows()[0].symbol).toBe('SPY');
+      expect(component.rows()[0].price).toBe(612);
+    });
+
+    it('tolerates a per-symbol quote failure by falling back to a zeroed row', () => {
+      fixture.detectChanges();
+      stocks.getQuote.and.callFake((sym: string) =>
+        sym === 'QQQ' ? throwError(() => new Error('fail')) : of(makeQuote({ symbol: sym }))
+      );
+      component.setCategory('etfs');
+      const qqqRow = component.rows().find(r => r.symbol === 'QQQ');
+      expect(qqqRow).toEqual({ symbol: 'QQQ', name: 'QQQ', price: 0, changePercent: 0, currency: 'USD' });
+    });
+
+    it('refreshActive forces a reload of the current category even if already loaded', () => {
+      fixture.detectChanges();
+      component.setCategory('stocks');
+      stocks.getQuote.calls.reset();
+      component.refreshActive();
+      expect(stocks.getQuote).toHaveBeenCalled();
+    });
+
+    it('does not re-fetch a category already loaded with the same symbol count', () => {
+      fixture.detectChanges();
+      component.setCategory('stocks');
+      stocks.getQuote.calls.reset();
+      component.setCategory('watch');
+      component.setCategory('stocks');
+      expect(stocks.getQuote).not.toHaveBeenCalled();
+    });
+
+    it('sets an empty row set for the watch category when the watchlist is empty', () => {
+      localStorage.setItem('stockapp.watchlist.v1', JSON.stringify([]));
+      fixture.detectChanges(); // ngOnInit: bootstrapWatchlist + loadCategory('watch') both see an empty list
+      expect(component.rows()).toEqual([]);
+    });
+
+    it('stops the loadingCategory flag even when the combined forkJoin path completes with an error subscriber', () => {
+      fixture.detectChanges();
+      // getQuote errors are already caught per-symbol via catchError, so forkJoin itself
+      // should always reach next(), never error() — this asserts loadingCategory settles to false.
+      component.setCategory('crypto');
+      expect(component.loadingCategory()).toBeFalse();
+    });
+  });
+
+  describe('watchlist persistence', () => {
+    it('reads the default watchlist when localStorage is empty', () => {
+      fixture.detectChanges();
+      expect(component.isWatched('TSLA')).toBeTrue();
+      expect(component.isWatched('SPY')).toBeFalse();
+    });
+
+    it('falls back to defaults when localStorage contains invalid JSON', () => {
+      localStorage.setItem('stockapp.watchlist.v1', '{not json');
+      fixture.detectChanges();
+      expect(component.isWatched('AAPL')).toBeTrue();
+    });
+
+    it('falls back to defaults when localStorage contains a non-array', () => {
+      localStorage.setItem('stockapp.watchlist.v1', JSON.stringify({ not: 'an array' }));
+      fixture.detectChanges();
+      expect(component.isWatched('AAPL')).toBeTrue();
+    });
+
+    it('falls back to defaults when the array contains non-string entries', () => {
+      localStorage.setItem('stockapp.watchlist.v1', JSON.stringify(['AAPL', 42]));
+      fixture.detectChanges();
+      expect(component.isWatched('AAPL')).toBeTrue();
+      expect(component.rows().length).toBe(5); // default watchlist, not the malformed one
+    });
+
+    it('isWatched returns false for an undefined symbol', () => {
+      fixture.detectChanges();
+      expect(component.isWatched(undefined)).toBeFalse();
+    });
+
+    it('toggleWatchlist adds a symbol not yet on the list and persists it', () => {
+      fixture.detectChanges();
+      component.toggleWatchlist('SPY');
+      expect(component.isWatched('SPY')).toBeTrue();
+      const stored = JSON.parse(localStorage.getItem('stockapp.watchlist.v1')!);
+      expect(stored).toContain('SPY');
+    });
+
+    it('toggleWatchlist removes a symbol already on the list', () => {
+      fixture.detectChanges();
+      component.toggleWatchlist('AAPL');
+      expect(component.isWatched('AAPL')).toBeFalse();
+      const stored = JSON.parse(localStorage.getItem('stockapp.watchlist.v1')!);
+      expect(stored).not.toContain('AAPL');
+    });
+
+    it('toggleWatchlist refreshes the watch category rows', () => {
+      // The default stub always resolves to an AAPL-shaped quote regardless of
+      // the requested symbol, so echo the requested symbol back to prove each
+      // row is keyed off its own quote.
+      stocks.getQuote.and.callFake((sym: string) => of(makeQuote({ symbol: sym })));
+      fixture.detectChanges();
+      component.setCategory('etfs');
+      component.toggleWatchlist('QQQ');
+      component.setCategory('watch');
+      expect(component.rows().some(r => r.symbol === 'QQQ')).toBeTrue();
+    });
+
+    it('does not throw when localStorage.setItem fails while toggling', () => {
+      fixture.detectChanges();
+      spyOn(localStorage, 'setItem').and.throwError('quota exceeded');
+      expect(() => component.toggleWatchlist('SPY')).not.toThrow();
+    });
+  });
+
+  describe('formatPrice', () => {
+    it('formats a normal USD value as currency', () => {
+      expect(component.formatPrice(231.5)).toBe('$231.50');
+    });
+
+    it('returns an em dash for undefined', () => {
+      expect(component.formatPrice(undefined)).toBe('—');
+    });
+
+    it('returns an em dash for NaN', () => {
+      expect(component.formatPrice(NaN)).toBe('—');
+    });
+
+    it('returns an em dash for exactly zero (placeholder row)', () => {
+      expect(component.formatPrice(0)).toBe('—');
+    });
+
+    it('uses up to 4 fraction digits under $1000', () => {
+      expect(component.formatPrice(0.1234)).toBe('$0.1234');
+    });
+
+    it('uses 2 fraction digits at/above $1000', () => {
+      expect(component.formatPrice(1234.5)).toBe('$1,234.50');
+    });
+
+    it('respects a custom currency code', () => {
+      expect(component.formatPrice(10, 'EUR')).toContain('10');
+    });
+
+    it('falls back to toFixed(2) when Intl.NumberFormat throws for a bad currency', () => {
+      expect(component.formatPrice(10, 'NOT_A_CURRENCY')).toBe('10.00');
+    });
+  });
+
+  describe('formatNumber', () => {
+    it('formats trillions', () => {
+      expect(component.formatNumber(3.58e12)).toBe('3.58T');
+    });
+    it('formats billions', () => {
+      expect(component.formatNumber(650.4e9)).toBe('650.40B');
+    });
+    it('formats millions', () => {
+      expect(component.formatNumber(58.23e6)).toBe('58.23M');
+    });
+    it('formats thousands', () => {
+      expect(component.formatNumber(4.2e3)).toBe('4.20K');
+    });
+    it('uses toLocaleString below one thousand', () => {
+      expect(component.formatNumber(842)).toBe((842).toLocaleString());
+    });
+    it('returns an em dash for undefined', () => {
+      expect(component.formatNumber(undefined)).toBe('—');
+    });
+    it('returns an em dash for NaN', () => {
+      expect(component.formatNumber(NaN)).toBe('—');
+    });
+  });
+
+  describe('formatPct', () => {
+    it('prefixes a positive value with +', () => {
+      expect(component.formatPct(1.82)).toBe('+1.82%');
+    });
+    it('does not prefix zero (strictly > 0, unlike trading-data.fmtPct)', () => {
+      expect(component.formatPct(0)).toBe('0.00%');
+    });
+    it('does not prefix a negative value', () => {
+      expect(component.formatPct(-1.24)).toBe('-1.24%');
+    });
+    it('returns an em dash for undefined', () => {
+      expect(component.formatPct(undefined)).toBe('—');
+    });
+    it('returns an em dash for NaN', () => {
+      expect(component.formatPct(NaN)).toBe('—');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('returns an empty string for a falsy epoch', () => {
+      expect(component.formatTime(undefined)).toBe('');
+      expect(component.formatTime(0)).toBe('');
+    });
+    it('formats a valid epoch as a locale date/time string', () => {
+      const epoch = 1700000000;
+      expect(component.formatTime(epoch)).toBe(new Date(epoch * 1000).toLocaleString());
+    });
+  });
+
+  describe('formatNewsDate', () => {
+    const NOW = new Date('2026-07-31T12:00:00Z').getTime();
+
+    beforeEach(() => jasmine.clock().mockDate(new Date(NOW)));
+    afterEach(() => jasmine.clock().uninstall());
+
+    it('returns an empty string for a falsy epoch', () => {
+      expect(component.formatNewsDate(0)).toBe('');
+    });
+
+    it('formats minutes-ago for < 1 hour', () => {
+      const epoch = Math.floor((NOW - 5 * 60000) / 1000);
+      expect(component.formatNewsDate(epoch)).toBe('5m ago');
+    });
+
+    it('formats hours-ago for < 24 hours', () => {
+      const epoch = Math.floor((NOW - 3 * 3600000) / 1000);
+      expect(component.formatNewsDate(epoch)).toBe('3h ago');
+    });
+
+    it('formats days-ago for < 7 days', () => {
+      const epoch = Math.floor((NOW - 2 * 86400000) / 1000);
+      expect(component.formatNewsDate(epoch)).toBe('2d ago');
+    });
+
+    it('formats a locale date for >= 7 days', () => {
+      const epoch = Math.floor((NOW - 10 * 86400000) / 1000);
+      const expected = new Date(epoch * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+      expect(component.formatNewsDate(epoch)).toBe(expected);
+    });
+  });
+
+  describe('derived signals', () => {
+    it('activeCategoryMeta reflects the active category', () => {
+      fixture.detectChanges();
+      expect(component.activeCategoryMeta().id).toBe('watch');
+      component.setCategory('crypto');
+      expect(component.activeCategoryMeta().id).toBe('crypto');
+    });
+
+    it('chart is null when history has fewer than 2 points', () => {
+      fixture.detectChanges();
+      expect(component.chart()).toBeNull();
+    });
+
+    it('chart builds real geometry for 2+ history points', () => {
+      stocks.getHistory.and.returnValue(of({
+        symbol: 'AAPL', currency: 'USD',
+        points: [{ time: 1, close: 10 }, { time: 2, close: 12 }, { time: 3, close: 11 }]
+      }));
+      fixture.detectChanges();
+      const chart = component.chart();
+      expect(chart).not.toBeNull();
+      expect(chart!.rising).toBeTrue(); // 11 >= 10
+      expect(chart!.firstClose).toBe(10);
+      expect(chart!.lastClose).toBe(11);
+    });
+  });
+});

--- a/src/app/stock/stock.component.ts
+++ b/src/app/stock/stock.component.ts
@@ -303,6 +303,9 @@ export class StockComponent implements OnInit, OnDestroy {
           this.updateRows(id, merged);
           this.loadingCategory.set(false);
         },
+        // Defensive: every quotes$ entry already funnels errors through
+        // catchError above, so forkJoin itself should never reject. Kept in
+        // case that guarantee changes.
         error: () => this.loadingCategory.set(false)
       });
   }
@@ -359,8 +362,7 @@ export class StockComponent implements OnInit, OnDestroy {
   // ---------- Formatting ----------
 
   formatPrice(value: number | undefined, currency = 'USD'): string {
-    if (value == null || isNaN(value) || value === 0) return value === 0 ? '—' : '—';
-    if (value === 0) return '—';
+    if (value == null || isNaN(value) || value === 0) return '—';
     try {
       return new Intl.NumberFormat(undefined, {
         style: 'currency',

--- a/src/app/trading-app-mobile/trading-app-mobile.component.spec.ts
+++ b/src/app/trading-app-mobile/trading-app-mobile.component.spec.ts
@@ -1,0 +1,256 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TradingAppMobileComponent } from './trading-app-mobile.component';
+import { HOLDINGS, ORDER_HISTORY, STOCKS, fmtMoney } from '../trading-app/trading-data';
+
+describe('TradingAppMobileComponent', () => {
+  let fixture: ComponentFixture<TradingAppMobileComponent>;
+  let component: TradingAppMobileComponent;
+
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    TestBed.configureTestingModule({ imports: [TradingAppMobileComponent] });
+    fixture = TestBed.createComponent(TradingAppMobileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => document.documentElement.removeAttribute('data-theme'));
+
+  it('creates with the expected defaults', () => {
+    expect(component.theme()).toBe('dark');
+    expect(component.screen()).toBe('home');
+    expect(component.category()).toBe('watch');
+    expect(component.activeSymbol()).toBe('AAPL');
+    expect(component.range()).toBe('1M');
+  });
+
+  it('picks up an existing data-theme attribute at construction time', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const f2 = TestBed.createComponent(TradingAppMobileComponent);
+    expect(f2.componentInstance.theme()).toBe('light');
+  });
+
+  describe('navigation', () => {
+    it('toggleTheme flips the signal and the DOM attribute', () => {
+      component.toggleTheme();
+      expect(component.theme()).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('goHome/goPortfolio/goOrders/goAccount switch screens', () => {
+      component.goPortfolio();
+      expect(component.screen()).toBe('portfolio');
+      component.goOrders();
+      expect(component.screen()).toBe('orders');
+      component.goAccount();
+      expect(component.screen()).toBe('account');
+      component.goHome();
+      expect(component.screen()).toBe('home');
+    });
+
+    it('selectSymbol sets the active symbol, clears the query, and navigates to the detail screen', () => {
+      component.searchQuery.set('nvda');
+      component.selectSymbol('NVDA');
+      expect(component.activeSymbol()).toBe('NVDA');
+      expect(component.searchQuery()).toBe('');
+      expect(component.screen()).toBe('detail');
+    });
+
+    it('setCategory / setRange / onSearchChange update their signals', () => {
+      component.setCategory('crypto');
+      expect(component.category()).toBe('crypto');
+      component.setRange('1Y');
+      expect(component.range()).toBe('1Y');
+      component.onSearchChange('tsla');
+      expect(component.searchQuery()).toBe('tsla');
+    });
+  });
+
+  describe('toggleWatch', () => {
+    it('adds and removes a symbol from the watchlist', () => {
+      component.toggleWatch('SPY');
+      expect(component.watchlist()).toContain('SPY');
+      component.toggleWatch('SPY');
+      expect(component.watchlist()).not.toContain('SPY');
+    });
+  });
+
+  describe('order ticket flow', () => {
+    it('openTicket / updateTicket / reviewTicket / backTicket / closeTicket', () => {
+      component.openTicket('AAPL', 'buy');
+      expect(component.ticket()).toEqual({ symbol: 'AAPL', side: 'buy', type: 'market', qty: '10', price: '', step: 'ticket' });
+      component.updateTicket({ qty: '3' });
+      expect(component.ticket()!.qty).toBe('3');
+      component.reviewTicket();
+      expect(component.ticket()!.step).toBe('confirm');
+      component.backTicket();
+      expect(component.ticket()!.step).toBe('ticket');
+      component.closeTicket();
+      expect(component.ticket()).toBeNull();
+    });
+
+    it('updateTicket is a no-op with no open ticket', () => {
+      component.updateTicket({ qty: '5' });
+      expect(component.ticket()).toBeNull();
+    });
+
+    it('placeOrder is a no-op with no open ticket', () => {
+      const before = component.orders().length;
+      component.placeOrder();
+      expect(component.orders().length).toBe(before);
+    });
+
+    it('placeOrder fills a market order and records it', () => {
+      const before = component.orders().length;
+      component.openTicket('AAPL', 'buy');
+      component.updateTicket({ qty: '4' });
+      component.placeOrder();
+      expect(component.orders().length).toBe(before + 1);
+      const placed = component.orders()[0];
+      expect(placed.qty).toBe(4);
+      expect(placed.price).toBe(STOCKS['AAPL'].price);
+      expect(placed.status).toBe('filled');
+      expect(component.ticket()!.step).toBe('success');
+    });
+
+    it('placeOrder leaves a limit order pending at the given price', () => {
+      component.openTicket('MSFT', 'sell');
+      component.updateTicket({ type: 'limit', qty: '2', price: '480' });
+      component.placeOrder();
+      expect(component.orders()[0].price).toBe(480);
+      expect(component.orders()[0].status).toBe('pending');
+    });
+
+    it('goToOrders closes the ticket and navigates to orders', () => {
+      component.openTicket('AAPL', 'buy');
+      component.goToOrders();
+      expect(component.ticket()).toBeNull();
+      expect(component.screen()).toBe('orders');
+    });
+  });
+
+  describe('account toggles', () => {
+    it('toggleNotif flips only the given key', () => {
+      const before = component.notif();
+      component.toggleNotif('fills');
+      expect(component.notif()).toEqual({ ...before, fills: !before.fills });
+    });
+
+    it('toggleTwoFactor flips the flag', () => {
+      const before = component.twoFactor();
+      component.toggleTwoFactor();
+      expect(component.twoFactor()).toBe(!before);
+    });
+  });
+
+  describe('derived view data', () => {
+    it('stock reflects direction and watch state', () => {
+      component.selectSymbol('AAPL');
+      expect(component.stock().isUp).toBeTrue();
+      expect(component.stock().isWatched).toBeTrue();
+    });
+
+    it('chart uses the compact 360x160 mobile viewport', () => {
+      const { path } = component.chart();
+      expect(path).toContain('360.00');
+    });
+
+    it('stats returns the 6 standard rows', () => {
+      expect(component.stats().length).toBe(6);
+    });
+
+    it('news mentions the active symbol', () => {
+      component.selectSymbol('TSLA');
+      expect(component.news().some(n => n.title.includes('TSLA'))).toBeTrue();
+    });
+
+    it('rows lists the watchlist for "watch" and the category list otherwise', () => {
+      expect(component.rows().length).toBe(5);
+      component.setCategory('etfs');
+      expect(component.rows().map(r => r.symbol)).toEqual(['SPY', 'QQQ', 'VTI']);
+    });
+
+    it('searchResults is empty for a blank query and matches by symbol/name otherwise', () => {
+      component.onSearchChange('');
+      expect(component.searchResults()).toEqual([]);
+      component.onSearchChange('apple');
+      expect(component.searchResults().some(r => r.symbol === 'AAPL')).toBeTrue();
+    });
+
+    it('holdings computes market value/gain per position', () => {
+      const rows = component.holdings();
+      expect(rows.length).toBe(HOLDINGS.length);
+      const holding = HOLDINGS.find(h => h.symbol === 'NVDA')!;
+      const nvda = rows.find(r => r.symbol === 'NVDA')!;
+      const gain = holding.shares * STOCKS['NVDA'].price - holding.shares * holding.avgCost;
+      expect(nvda.isUp).toBe(gain >= 0);
+    });
+
+    it('portfolio totals allocate to 100% across holdings', () => {
+      const p = component.portfolio();
+      const totalPct = p.allocation.reduce((s, a) => s + a.pct, 0);
+      expect(totalPct).toBeCloseTo(100, 5);
+    });
+
+    it('orderRows maps status flags for each order', () => {
+      const rows = component.orderRows();
+      expect(rows.length).toBe(ORDER_HISTORY.length);
+      expect(rows.find(r => r.id === 'ORD-10482')!.isFilled).toBeTrue();
+      expect(rows.find(r => r.id === 'ORD-10461')!.isPending).toBeTrue();
+      expect(rows.find(r => r.id === 'ORD-10439')!.isCanceled).toBeTrue();
+    });
+
+    it('notifRows exposes the 3 toggles with current state', () => {
+      const rows = component.notifRows();
+      expect(rows.map(r => r.key)).toEqual(['price', 'fills', 'news']);
+      expect(rows.find(r => r.key === 'price')!.on).toBeTrue();
+    });
+
+    describe('ticketView', () => {
+      it('is null with no open ticket', () => {
+        expect(component.ticketView()).toBeNull();
+      });
+
+      it('computes the estimated total and price label for a market order', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ qty: '2' });
+        const view = component.ticketView()!;
+        expect(view.estLabel).toBe(fmtMoney(STOCKS['AAPL'].price * 2));
+        expect(view.priceLabel).toContain('Market price');
+      });
+
+      it('needsPrice/priceFieldLabel reflect limit vs. stop order types', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ type: 'limit' });
+        expect(component.ticketView()!.priceFieldLabel).toBe('Limit price');
+        component.updateTicket({ type: 'stop' });
+        expect(component.ticketView()!.priceFieldLabel).toBe('Stop price');
+      });
+
+      it('success summary reports the fill outcome', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ qty: '5' });
+        component.placeOrder();
+        expect(component.ticketView()!.successSummary).toContain('Bought 5 shares of AAPL');
+      });
+    });
+
+    describe('showTabBar / tabHomeActive', () => {
+      it('showTabBar is true everywhere except the detail screen', () => {
+        expect(component.showTabBar()).toBeTrue();
+        component.selectSymbol('AAPL'); // -> detail
+        expect(component.showTabBar()).toBeFalse();
+        component.goPortfolio();
+        expect(component.showTabBar()).toBeTrue();
+      });
+
+      it('tabHomeActive is true on both home and detail (drill-down still highlights Home)', () => {
+        expect(component.tabHomeActive()).toBeTrue(); // home
+        component.selectSymbol('AAPL'); // -> detail
+        expect(component.tabHomeActive()).toBeTrue();
+        component.goPortfolio();
+        expect(component.tabHomeActive()).toBeFalse();
+      });
+    });
+  });
+});

--- a/src/app/trading-app/trading-app.component.spec.ts
+++ b/src/app/trading-app/trading-app.component.spec.ts
@@ -1,0 +1,376 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TradingAppComponent } from './trading-app.component';
+import { HOLDINGS, ORDER_HISTORY, STOCKS, fmtMoney } from './trading-data';
+
+describe('TradingAppComponent', () => {
+  let fixture: ComponentFixture<TradingAppComponent>;
+  let component: TradingAppComponent;
+
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    TestBed.configureTestingModule({ imports: [TradingAppComponent] });
+    fixture = TestBed.createComponent(TradingAppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => document.documentElement.removeAttribute('data-theme'));
+
+  it('creates with the expected defaults', () => {
+    expect(component.theme()).toBe('dark');
+    expect(component.screen()).toBe('dashboard');
+    expect(component.category()).toBe('watch');
+    expect(component.activeSymbol()).toBe('AAPL');
+    expect(component.range()).toBe('1M');
+  });
+
+  it('picks up an existing data-theme attribute at construction time', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const f2 = TestBed.createComponent(TradingAppComponent);
+    expect(f2.componentInstance.theme()).toBe('light');
+  });
+
+  describe('navigation setters', () => {
+    it('toggleTheme flips the signal and the DOM attribute', () => {
+      component.toggleTheme();
+      expect(component.theme()).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      component.toggleTheme();
+      expect(component.theme()).toBe('dark');
+    });
+
+    it('setScreen changes the active screen', () => {
+      component.setScreen('orders');
+      expect(component.screen()).toBe('orders');
+    });
+
+    it('setCategory changes the active category', () => {
+      component.setCategory('crypto');
+      expect(component.category()).toBe('crypto');
+    });
+
+    it('selectSymbol sets the active symbol and clears the search query', () => {
+      component.searchQuery.set('nvda');
+      component.selectSymbol('NVDA');
+      expect(component.activeSymbol()).toBe('NVDA');
+      expect(component.searchQuery()).toBe('');
+    });
+
+    it('setRange changes the active range', () => {
+      component.setRange('1Y');
+      expect(component.range()).toBe('1Y');
+    });
+
+    it('onSearchChange updates the search query', () => {
+      component.onSearchChange('tsla');
+      expect(component.searchQuery()).toBe('tsla');
+    });
+  });
+
+  describe('toggleWatch', () => {
+    it('adds a symbol that is not on the watchlist', () => {
+      expect(component.watchlist()).not.toContain('SPY');
+      component.toggleWatch('SPY');
+      expect(component.watchlist()).toContain('SPY');
+    });
+
+    it('removes a symbol already on the watchlist', () => {
+      expect(component.watchlist()).toContain('AAPL');
+      component.toggleWatch('AAPL');
+      expect(component.watchlist()).not.toContain('AAPL');
+    });
+  });
+
+  describe('order ticket flow', () => {
+    it('openTicket seeds a fresh market ticket in the ticket step', () => {
+      component.openTicket('MSFT', 'sell');
+      expect(component.ticket()).toEqual({ symbol: 'MSFT', side: 'sell', type: 'market', qty: '10', price: '', step: 'ticket' });
+    });
+
+    it('updateTicket merges a partial patch onto the current ticket', () => {
+      component.openTicket('AAPL', 'buy');
+      component.updateTicket({ qty: '25', type: 'limit' });
+      expect(component.ticket()).toEqual(jasmine.objectContaining({ qty: '25', type: 'limit', symbol: 'AAPL' }));
+    });
+
+    it('updateTicket is a no-op when there is no open ticket', () => {
+      expect(component.ticket()).toBeNull();
+      component.updateTicket({ qty: '99' });
+      expect(component.ticket()).toBeNull();
+    });
+
+    it('reviewTicket advances to the confirm step', () => {
+      component.openTicket('AAPL', 'buy');
+      component.reviewTicket();
+      expect(component.ticket()!.step).toBe('confirm');
+    });
+
+    it('backTicket returns to the ticket step', () => {
+      component.openTicket('AAPL', 'buy');
+      component.reviewTicket();
+      component.backTicket();
+      expect(component.ticket()!.step).toBe('ticket');
+    });
+
+    it('closeTicket clears the ticket', () => {
+      component.openTicket('AAPL', 'buy');
+      component.closeTicket();
+      expect(component.ticket()).toBeNull();
+    });
+
+    it('placeOrder is a no-op when there is no open ticket', () => {
+      const before = component.orders().length;
+      component.placeOrder();
+      expect(component.orders().length).toBe(before);
+    });
+
+    it('placeOrder fills a market order immediately at the current price', () => {
+      const before = component.orders().length;
+      component.openTicket('AAPL', 'buy');
+      component.updateTicket({ qty: '5' });
+      component.placeOrder();
+
+      expect(component.orders().length).toBe(before + 1);
+      const placed = component.orders()[0];
+      expect(placed.symbol).toBe('AAPL');
+      expect(placed.side).toBe('buy');
+      expect(placed.type).toBe('Market');
+      expect(placed.qty).toBe(5);
+      expect(placed.price).toBe(STOCKS['AAPL'].price);
+      expect(placed.status).toBe('filled');
+
+      const ticket = component.ticket()!;
+      expect(ticket.step).toBe('success');
+      expect(ticket.status).toBe('filled');
+      expect(ticket.id).toMatch(/^ORD-\d+$/);
+    });
+
+    it('placeOrder leaves a limit order pending at the specified price', () => {
+      component.openTicket('MSFT', 'sell');
+      component.updateTicket({ type: 'limit', qty: '3', price: '500' });
+      component.placeOrder();
+
+      const placed = component.orders()[0];
+      expect(placed.type).toBe('Limit');
+      expect(placed.price).toBe(500);
+      expect(placed.status).toBe('pending');
+      expect(component.ticket()!.status).toBe('pending');
+    });
+
+    it('placeOrder leaves a stop order pending', () => {
+      component.openTicket('MSFT', 'sell');
+      component.updateTicket({ type: 'stop', qty: '3', price: '400' });
+      component.placeOrder();
+      expect(component.orders()[0].type).toBe('Stop');
+      expect(component.orders()[0].status).toBe('pending');
+    });
+
+    it('placeOrder falls back to the market price when a limit price is blank/invalid', () => {
+      component.openTicket('AAPL', 'buy');
+      component.updateTicket({ type: 'limit', qty: '1', price: '' });
+      component.placeOrder();
+      expect(component.orders()[0].price).toBe(STOCKS['AAPL'].price);
+    });
+
+    it('placeOrder treats a non-numeric quantity as 0', () => {
+      component.openTicket('AAPL', 'buy');
+      component.updateTicket({ qty: 'abc' });
+      component.placeOrder();
+      expect(component.orders()[0].qty).toBe(0);
+    });
+
+    it('goToOrders closes the ticket and switches to the orders screen', () => {
+      component.openTicket('AAPL', 'buy');
+      component.goToOrders();
+      expect(component.ticket()).toBeNull();
+      expect(component.screen()).toBe('orders');
+    });
+  });
+
+  describe('account toggles', () => {
+    it('toggleNotif flips exactly the given key', () => {
+      const before = component.notif();
+      component.toggleNotif('news');
+      expect(component.notif()).toEqual({ ...before, news: !before.news });
+    });
+
+    it('toggleTwoFactor flips the flag', () => {
+      const before = component.twoFactor();
+      component.toggleTwoFactor();
+      expect(component.twoFactor()).toBe(!before);
+    });
+  });
+
+  describe('derived view data', () => {
+    it('stock reflects the active symbol, up direction, and watch state', () => {
+      component.selectSymbol('AAPL');
+      const s = component.stock();
+      expect(s.symbol).toBe('AAPL');
+      expect(s.isUp).toBeTrue();
+      expect(s.isDown).toBeFalse();
+      expect(s.isWatched).toBeTrue(); // AAPL is in the default watchlist
+    });
+
+    it('stock reports isDown for a symbol with a negative change', () => {
+      component.selectSymbol('NVDA'); // chgPct -1.24 in trading-data
+      const s = component.stock();
+      expect(s.isDown).toBeTrue();
+      expect(s.isUp).toBeFalse();
+    });
+
+    it('stock reports isWatched=false for a symbol not on the watchlist', () => {
+      component.selectSymbol('SPY');
+      expect(component.stock().isWatched).toBeFalse();
+    });
+
+    it('chart geometry updates when the symbol or range changes', () => {
+      const c1 = component.chart();
+      component.setRange('1Y');
+      const c2 = component.chart();
+      expect(c1.path).not.toBe(c2.path);
+    });
+
+    it('stats returns 6 labeled rows for the active symbol', () => {
+      const stats = component.stats();
+      expect(stats.length).toBe(6);
+      expect(stats.map(s => s.label)).toEqual(['Prev close', 'Day range', '52W range', 'Volume', 'Market cap', 'Exchange']);
+    });
+
+    it('news mentions the active symbol/company across all 3 items', () => {
+      component.selectSymbol('TSLA');
+      const items = component.news();
+      expect(items.length).toBe(3);
+      expect(items.some(n => n.title.includes('TSLA'))).toBeTrue();
+    });
+
+    it('rows lists the watchlist when category is "watch"', () => {
+      const rows = component.rows();
+      expect(rows.map(r => r.symbol).sort()).toEqual(['AAPL', 'GOOGL', 'MSFT', 'NVDA', 'TSLA'].sort());
+    });
+
+    it('rows lists the category symbols when category is not "watch"', () => {
+      component.setCategory('etfs');
+      const rows = component.rows();
+      expect(rows.map(r => r.symbol)).toEqual(['SPY', 'QQQ', 'VTI']);
+    });
+
+    it('rows marks the active symbol row', () => {
+      component.selectSymbol('MSFT');
+      const row = component.rows().find(r => r.symbol === 'MSFT');
+      expect(row!.isActive).toBeTrue();
+      expect(component.rows().find(r => r.symbol === 'AAPL')!.isActive).toBeFalse();
+    });
+
+    it('searchResults is empty for a blank query', () => {
+      component.onSearchChange('   ');
+      expect(component.searchResults()).toEqual([]);
+    });
+
+    it('searchResults matches by symbol or name, case-insensitively, capped at 8', () => {
+      component.onSearchChange('a');
+      const results = component.searchResults();
+      expect(results.length).toBeLessThanOrEqual(8);
+      expect(results.some(r => r.symbol === 'AAPL')).toBeTrue();
+    });
+
+    it('holdings computes market value and gain/loss per position', () => {
+      const rows = component.holdings();
+      expect(rows.length).toBe(HOLDINGS.length);
+      const holding = HOLDINGS.find(h => h.symbol === 'AAPL')!;
+      const aapl = rows.find(r => r.symbol === 'AAPL')!;
+      const expectedValue = holding.shares * STOCKS['AAPL'].price;
+      const expectedCost = holding.shares * holding.avgCost;
+      expect(aapl.valueLabel).toBe(fmtMoney(expectedValue));
+      expect(aapl.isUp).toBe(expectedValue - expectedCost >= 0);
+    });
+
+    it('portfolio totals equal the sum of holding market values and costs', () => {
+      const p = component.portfolio();
+      let expectedValue = 0, expectedCost = 0;
+      for (const h of HOLDINGS) {
+        expectedValue += h.shares * STOCKS[h.symbol].price;
+        expectedCost += h.shares * h.avgCost;
+      }
+      expect(p.gainUp).toBe(expectedValue - expectedCost >= 0);
+      expect(p.allocation.length).toBe(HOLDINGS.length);
+      const totalPct = p.allocation.reduce((s, a) => s + a.pct, 0);
+      expect(totalPct).toBeCloseTo(100, 5);
+    });
+
+    it('orderRows maps each order and flags its status', () => {
+      const rows = component.orderRows();
+      expect(rows.length).toBe(ORDER_HISTORY.length);
+      const filled = rows.find(r => r.id === 'ORD-10482')!;
+      expect(filled.isFilled).toBeTrue();
+      expect(filled.isPending).toBeFalse();
+      expect(filled.isCanceled).toBeFalse();
+      const pending = rows.find(r => r.id === 'ORD-10461')!;
+      expect(pending.isPending).toBeTrue();
+      const canceled = rows.find(r => r.id === 'ORD-10439')!;
+      expect(canceled.isCanceled).toBeTrue();
+    });
+
+    it('orderRows grows after placeOrder prepends a new order', () => {
+      const before = component.orderRows().length;
+      component.openTicket('AAPL', 'buy');
+      component.placeOrder();
+      expect(component.orderRows().length).toBe(before + 1);
+    });
+
+    it('notifRows exposes the 3 toggles with the correct on/off state', () => {
+      const rows = component.notifRows();
+      expect(rows.map(r => r.key)).toEqual(['price', 'fills', 'news']);
+      expect(rows.find(r => r.key === 'news')!.on).toBeFalse();
+      component.toggleNotif('news');
+      expect(component.notifRows().find(r => r.key === 'news')!.on).toBeTrue();
+    });
+
+    describe('ticketView', () => {
+      it('is null when there is no open ticket', () => {
+        expect(component.ticketView()).toBeNull();
+      });
+
+      it('computes an estimated total for a market order from the live price', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ qty: '10' });
+        const view = component.ticketView()!;
+        expect(view.needsPrice).toBeFalse();
+        expect(view.estLabel).toBe(fmtMoney(STOCKS['AAPL'].price * 10));
+      });
+
+      it('needsPrice is true and shows the right field label for limit/stop orders', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ type: 'limit' });
+        expect(component.ticketView()!.needsPrice).toBeTrue();
+        expect(component.ticketView()!.priceFieldLabel).toBe('Limit price');
+        component.updateTicket({ type: 'stop' });
+        expect(component.ticketView()!.priceFieldLabel).toBe('Stop price');
+      });
+
+      it('reflects the current step and verb', () => {
+        component.openTicket('MSFT', 'sell');
+        expect(component.ticketView()!.verb).toBe('Sell');
+        expect(component.ticketView()!.step).toBe('ticket');
+        component.reviewTicket();
+        expect(component.ticketView()!.step).toBe('confirm');
+      });
+
+      it('builds a success summary that reflects fill status', () => {
+        component.openTicket('AAPL', 'buy');
+        component.updateTicket({ qty: '5' });
+        component.placeOrder();
+        const view = component.ticketView()!;
+        expect(view.step).toBe('success');
+        expect(view.successSummary).toContain('Bought 5 shares of AAPL');
+        expect(view.successSummary).toContain('filled at');
+      });
+
+      it('success summary mentions a pending fill for non-market orders', () => {
+        component.openTicket('MSFT', 'sell');
+        component.updateTicket({ type: 'limit', qty: '2', price: '999' });
+        component.placeOrder();
+        expect(component.ticketView()!.successSummary).toContain('pending fill');
+      });
+    });
+  });
+});

--- a/src/app/trading-app/trading-data.spec.ts
+++ b/src/app/trading-app/trading-data.spec.ts
@@ -1,0 +1,204 @@
+import {
+  ALLOC_COLORS,
+  CATEGORIES,
+  CATEGORY_SYMBOLS,
+  HOLDINGS,
+  NEWS_PUBLISHERS,
+  ORDER_HISTORY,
+  RANGE_COUNTS,
+  RANGE_IDS,
+  STOCKS,
+  buildChart,
+  fmtMoney,
+  fmtNum,
+  fmtPct,
+  seededSeries
+} from './trading-data';
+
+describe('trading-data formatters', () => {
+  describe('fmtMoney', () => {
+    it('formats a positive number as USD with two decimals', () => {
+      expect(fmtMoney(1234.5)).toBe('$1,234.50');
+    });
+
+    it('formats zero', () => {
+      expect(fmtMoney(0)).toBe('$0.00');
+    });
+
+    it('formats a negative number', () => {
+      expect(fmtMoney(-42.1)).toBe('$-42.10');
+    });
+
+    it('returns an em dash for null', () => {
+      expect(fmtMoney(null)).toBe('—');
+    });
+
+    it('returns an em dash for undefined', () => {
+      expect(fmtMoney(undefined)).toBe('—');
+    });
+
+    it('returns an em dash for NaN', () => {
+      expect(fmtMoney(NaN)).toBe('—');
+    });
+  });
+
+  describe('fmtPct', () => {
+    it('prefixes a positive value with +', () => {
+      expect(fmtPct(1.8)).toBe('+1.80%');
+    });
+
+    it('prefixes zero with + (>= 0 branch)', () => {
+      expect(fmtPct(0)).toBe('+0.00%');
+    });
+
+    it('does not prefix a negative value', () => {
+      expect(fmtPct(-3.375)).toBe('-3.38%');
+    });
+  });
+
+  describe('fmtNum', () => {
+    it('returns an em dash for 0 (falsy)', () => {
+      expect(fmtNum(0)).toBe('—');
+    });
+
+    it('formats billions', () => {
+      expect(fmtNum(2_350_000_000)).toBe('2.35B');
+    });
+
+    it('formats millions', () => {
+      expect(fmtNum(58_230_000)).toBe('58.23M');
+    });
+
+    it('formats thousands', () => {
+      expect(fmtNum(4_500)).toBe('4.5K');
+    });
+
+    it('returns the plain number below one thousand', () => {
+      expect(fmtNum(842)).toBe('842');
+    });
+  });
+
+  describe('seededSeries', () => {
+    it('returns `count` points', () => {
+      expect(seededSeries('AAPL1M', 100, 30).length).toBe(30);
+    });
+
+    it('is deterministic for the same seed', () => {
+      const a = seededSeries('AAPL1M', 231.52, 30);
+      const b = seededSeries('AAPL1M', 231.52, 30);
+      expect(a).toEqual(b);
+    });
+
+    it('produces a different series for a different seed', () => {
+      const a = seededSeries('AAPL1M', 231.52, 30);
+      const b = seededSeries('MSFT1M', 468.20, 30);
+      expect(a).not.toEqual(b);
+    });
+
+    it('forces the final point to equal the base price', () => {
+      const series = seededSeries('NVDA1Y', 142.85, 52);
+      expect(series[series.length - 1]).toBe(142.85);
+    });
+
+    it('keeps every point within the [0.75x, 1.15x] clamp band', () => {
+      const base = 500;
+      const series = seededSeries('QQQ3M', base, 45);
+      for (const p of series) {
+        expect(p).toBeGreaterThanOrEqual(base * 0.75 - 1e-9);
+        expect(p).toBeLessThanOrEqual(base * 1.15 + 1e-9);
+      }
+    });
+
+    it('handles a single-point series without dividing by zero', () => {
+      const series = seededSeries('X', 10, 1);
+      expect(series.length).toBe(1);
+      expect(series[0]).toBe(10);
+    });
+  });
+
+  describe('buildChart', () => {
+    it('starts the path with M and joins remaining points with L', () => {
+      const { path } = buildChart([1, 2, 3]);
+      expect(path.startsWith('M')).toBeTrue();
+      expect(path.split(' ').filter(seg => seg.startsWith('L')).length).toBe(2);
+    });
+
+    it('closes the area path back to the baseline', () => {
+      const { areaPath } = buildChart([1, 2, 3]);
+      expect(areaPath.endsWith('Z')).toBeTrue();
+    });
+
+    it('marks rising when the series ends at or above where it started', () => {
+      expect(buildChart([1, 2, 3]).rising).toBeTrue();
+      expect(buildChart([1, 2, 3]).falling).toBeFalse();
+    });
+
+    it('marks falling when the series ends below where it started', () => {
+      expect(buildChart([3, 2, 1]).rising).toBeFalse();
+      expect(buildChart([3, 2, 1]).falling).toBeTrue();
+    });
+
+    it('treats an equal start/end as rising (>=, not >)', () => {
+      expect(buildChart([5, 9, 1, 5]).rising).toBeTrue();
+    });
+
+    it('does not divide by zero when every point is equal (span=0 falls back to 1)', () => {
+      const { path } = buildChart([7, 7, 7]);
+      expect(path).not.toContain('NaN');
+      expect(path).not.toContain('Infinity');
+    });
+
+    it('uses the default 800x220 viewport when none is given', () => {
+      const { path } = buildChart([1, 2]);
+      // last point's x should be the full default width (800)
+      expect(path).toContain('800.00');
+    });
+
+    it('honors a custom width/height and switches to the tighter 10px padding', () => {
+      const { path, areaPath } = buildChart([1, 2], 360, 160);
+      expect(path).toContain('360.00');
+      // padBottom is 10 for height < 200, so the area path closes at y=150
+      expect(areaPath).toContain(',150');
+    });
+  });
+});
+
+describe('trading-data constants', () => {
+  it('RANGE_COUNTS has an entry for every RANGE_IDS value', () => {
+    for (const r of RANGE_IDS) {
+      expect(RANGE_COUNTS[r]).toBeGreaterThan(0);
+    }
+  });
+
+  it('CATEGORY_SYMBOLS covers every non-watch CATEGORIES id', () => {
+    for (const c of CATEGORIES) {
+      if (c.id === 'watch') continue;
+      expect((CATEGORY_SYMBOLS as Record<string, string[]>)[c.id]?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every symbol referenced by CATEGORY_SYMBOLS exists in STOCKS', () => {
+    for (const symbols of Object.values(CATEGORY_SYMBOLS)) {
+      for (const sym of symbols) {
+        expect(STOCKS[sym]).withContext(sym).toBeDefined();
+      }
+    }
+  });
+
+  it('every HOLDINGS symbol exists in STOCKS', () => {
+    for (const h of HOLDINGS) {
+      expect(STOCKS[h.symbol]).withContext(h.symbol).toBeDefined();
+    }
+  });
+
+  it('every ORDER_HISTORY symbol exists in STOCKS', () => {
+    for (const o of ORDER_HISTORY) {
+      expect(STOCKS[o.symbol]).withContext(o.symbol).toBeDefined();
+    }
+  });
+
+  it('has at least one alloc color and one news publisher', () => {
+    expect(ALLOC_COLORS.length).toBeGreaterThan(0);
+    expect(NEWS_PUBLISHERS.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Every source file except `app.component.ts` had zero test coverage — `StockService`, `StockComponent`, `TradingAppComponent`, `TradingAppMobileComponent`, and `trading-data.ts` were all untested. This adds 5 spec files / 209 tests, verified against a real headless Chromium run (`ng test --code-coverage`), not just typechecked.

- **`trading-data.spec.ts`** — the pure formatters (`fmtMoney`, `fmtPct`, `fmtNum`) and chart-geometry function (`buildChart`, `seededSeries`), plus data-integrity checks (every symbol referenced by holdings/orders/categories actually exists in `STOCKS`).
- **`stock.service.spec.ts`** — all four HTTP methods via `HttpTestingController`: error paths, URL encoding of symbols, and malformed/partial API response handling.
- **`stock.component.spec.ts`** — theme persistence, debounced search (`fakeAsync`/`tick`), symbol selection, range switching, keyboard nav (arrow/home/end on category tabs), category loading with per-symbol failure tolerance via `forkJoin`, watchlist persistence including malformed `localStorage`, and every formatter.
- **`trading-app.component.spec.ts`** / **`trading-app-mobile.component.spec.ts`** — navigation, the full buy/sell order-ticket flow (market/limit/stop, fill vs. pending), and every computed signal.

**Result: 100% function coverage on every file except `stock.component.ts`** (61/62, 99.46%). The one gap is a `forkJoin` error handler that's genuinely unreachable — every per-symbol request already routes through `catchError(() => of(null))` before reaching it, so `forkJoin` itself can't error under normal operation. Documented with a comment rather than covered by a test that would just mock `forkJoin` to fake-trigger dead code.

## Also fixes a real bug found while chasing that gap

`stock.component.ts`'s `formatPrice()` had:
```ts
if (value == null || isNaN(value) || value === 0) return value === 0 ? '—' : '—';
if (value === 0) return '—';  // unreachable — the line above already handles value === 0
```
The second line was provably dead code, not a test gap, so it's removed rather than routed around.

## Reviewer notes

- Headless Chromium wasn't available in earlier sessions on this arm64 sandbox; this run found a working `headless_shell` binary (via `LD_LIBRARY_PATH` pointing at a stub `libasound.so.2`), so the full suite was actually executed, not just typechecked. CI runs on a standard runner and doesn't need this workaround.
- One test bug was caught and fixed during development: a watchlist-refresh assertion initially failed because the default mock always returned an AAPL-shaped quote regardless of the requested symbol — fixed the test (`callFake` to echo the requested symbol), not the source.

## Test plan
- [x] `ng test --no-watch --code-coverage` → 209/209 passing
- [x] Function coverage: 100% on `trading-data.ts`, `stock.service.ts`, `trading-app.component.ts`, `trading-app-mobile.component.ts`; 99.46% (61/62, documented gap) on `stock.component.ts`
- [x] `ng build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)