### PR TITLE
deps: update Angular CLI, GitHub Actions, and base image digests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # dev-22-bullseye
-FROM mcr.microsoft.com/devcontainers/javascript-node@sha256:f42ce084bfbf78cd759d0b1635c882e88b36be45d55560786272bb852ac8c5a5
+FROM mcr.microsoft.com/devcontainers/javascript-node@sha256:8e293115f2d7fbe69d8934ea59f95d5eeeaeb9a3ca09d0bd9b08a15a8c8bec13
 
 RUN npm install -g @angular/cli
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/master_angular.yml
+++ b/.github/workflows/master_angular.yml
@@ -52,7 +52,7 @@ jobs:
           name: node-app
 
       - name: Login to Azure
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_7A2C99EB116D488B8B9C9DDECBFAD5E7 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_555EBE2214A24A89858DAFFDE52357B1 }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -71,6 +71,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 # ---- Stage 1: build ---------------------------------------------------------
 # node:24-alpine — matches the Node version used in CI.
-FROM node@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS build
+FROM node@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS build
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "22.1.2",
-        "@angular/cli": "22.1.2",
+        "@angular-devkit/build-angular": "22.1.3",
+        "@angular/cli": "22.1.3",
         "@angular/compiler-cli": "22.1.0",
         "@capacitor/cli": "8.5.0",
         "@types/jasmine": "6.0.0",
@@ -52,13 +52,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2201.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.2.tgz",
-      "integrity": "sha512-RRG3JA3hPH0ypbDIyquZt9DDTP5pOMPgqQ/iLSkok1MZdKiOgpk6FGfXCa1ei72SwlX7lnJdq94d6WWdqpbyKg==",
+      "version": "0.2201.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2201.3.tgz",
+      "integrity": "sha512-5WX6rooTQZCh+yE9k3O5hc7nnQtzy1nw6fQpaTuCzIgPG8teQuVtdxegBsM3OcjJac1r+qJLo+KmTRfnqcfsyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -71,18 +71,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-22.1.2.tgz",
-      "integrity": "sha512-+jngKxBnagJcfrFcNXHfb0bmKWMmxTPEba0T9KPXmtgv+jk6AUlVhWfcU3fpBKrRZs9ChxyVWMDnI56FNItpvA==",
-      "deprecated": "Angular's Webpack support is deprecated. Use the esbuild and Vite-based \"@angular/build\" package instead.",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-22.1.3.tgz",
+      "integrity": "sha512-xzmD1XNy75X4Eeb16DU26C3K07M6uHDWO+WNsIqbsJrhupes9IBELb9AWIlo4WHTmj96/F7rHlqM0Wok1J54Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.2",
-        "@angular-devkit/build-webpack": "0.2201.2",
-        "@angular-devkit/core": "22.1.2",
-        "@angular/build": "22.1.2",
+        "@angular-devkit/architect": "0.2201.3",
+        "@angular-devkit/build-webpack": "0.2201.3",
+        "@angular-devkit/core": "22.1.3",
+        "@angular/build": "22.1.3",
         "@babel/core": "8.0.1",
         "@babel/generator": "8.0.0",
         "@babel/helper-annotate-as-pure": "8.0.0",
@@ -93,7 +92,7 @@
         "@babel/preset-env": "8.0.2",
         "@babel/runtime": "8.0.0",
         "@discoveryjs/json-ext": "1.1.0",
-        "@ngtools/webpack": "22.1.2",
+        "@ngtools/webpack": "22.1.3",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.5.4",
         "babel-loader": "10.1.1",
@@ -114,7 +113,7 @@
         "ora": "9.4.1",
         "picomatch": "4.0.5",
         "piscina": "5.2.0",
-        "postcss": "8.5.19",
+        "postcss": "8.5.25",
         "postcss-loader": "8.2.1",
         "resolve-url-loader": "5.0.0",
         "rxjs": "7.8.2",
@@ -147,7 +146,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.2",
+        "@angular/ssr": "^22.1.3",
         "browser-sync": "^3.0.2",
         "karma": "^6.3.0",
         "ng-packagr": "^22.0.0",
@@ -188,13 +187,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2201.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2201.2.tgz",
-      "integrity": "sha512-mRt2JsrQVBI/CKoD6yxFJRsTb9Xv20kmJDjzuAiuxAbwXLjXDgZWqqibPjt3bd78IHDntE5+n5ZNjsj0vR9lJA==",
+      "version": "0.2201.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2201.3.tgz",
+      "integrity": "sha512-gCCXIe3XMu3KQ1xj9o3hXeeImqEM8eWYCWhFJ3AJpSj8GIWtoGCj+1pXIpHR+1vWRfzboTkXxPeptevj7NEJIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.2",
+        "@angular-devkit/architect": "0.2201.3",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -208,9 +207,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.2.tgz",
-      "integrity": "sha512-tF1oEE7KPs8I08HJQmH5e4GkLUB3+MXXy8t6gMJULaLFxZYP9K1oXRFLappMpdm9OIbEXOChk23hrho0By9aYg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.1.3.tgz",
+      "integrity": "sha512-ASK8oZVElt/Zpz5FrzJjLnnUbzp/fW57eFFSRgpA+n9KRnuFi6YvNdSS3HkG5049Jcukce+PiMBdfzw/jBVkEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -236,13 +235,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.2.tgz",
-      "integrity": "sha512-Lw6NvW5rfMUl/2dsuWY8l6wlfWCuYBzCYSSqqliLPDco0doGzBliHwY9uxuzuUKZgOl5TvuVyvEo0t3o4Jj4GA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.1.3.tgz",
+      "integrity": "sha512-ebY5bwZVB0onxxyTbJch//VidVVV8jo/F13n+TV5s/3ZywsC3/XZsfMHaxlFmpvP/G17+/C9JVoEXT+uwjT+/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
         "jsonc-parser": "3.3.1",
         "magic-string": "1.0.0",
         "ora": "9.4.1",
@@ -255,14 +254,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.2.tgz",
-      "integrity": "sha512-DE/3o17JTel4EBt2BA4DqJYeBBuz5Ef/kf1jL9YZTyJu4SrLr/HI79K14jFr0VRIxzcqG92FdIzfLDxbOesQsg==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.1.3.tgz",
+      "integrity": "sha512-Hjen3LcVZUCNZy+epgO+/PMUpD/L8Y4vODS+Q8F0Lkva7YWQwycbJtrEr6xvFfMxp6xexxxIwB9+5b8voKSihQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2201.2",
+        "@angular-devkit/architect": "0.2201.3",
         "@babel/core": "8.0.1",
         "@babel/helper-annotate-as-pure": "8.0.0",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -304,7 +303,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.1.2",
+        "@angular/ssr": "^22.1.3",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -463,19 +462,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.2.tgz",
-      "integrity": "sha512-gzB+iuZzB507DAkZb9s5+Jw8QRzOBolUhHEuAKH74xF6oWlEP5JdexfTgti45SjXaKKqeYpODJFnUmSQQJRhxA==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.1.3.tgz",
+      "integrity": "sha512-GB1Pv8CXAHXE2/hqiwSGD6JRIyT4wswadjH1j3DH2+6os1zc7CBm28/YtlKPPIHZKVOZLDqV6uW+bRQTtdOw2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2201.2",
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/architect": "0.2201.3",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "@inquirer/prompts": "8.5.2",
         "@listr2/prompt-adapter-inquirer": "4.2.4",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.1.2",
+        "@schematics/angular": "22.1.3",
         "jsonc-parser": "3.3.1",
         "listr2": "10.2.2",
         "npm-package-arg": "14.0.0",
@@ -1075,9 +1074,9 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4521,9 +4520,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
-      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4543,9 +4542,10 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-22.1.2.tgz",
-      "integrity": "sha512-5o3zbOdEHv5+wjRCMN+t6RBou28dbPkio5/rxEJBsQ9iEq11K+atsSKEaZXBMUhYr9nLYR8Pckm5Cqx2FP9R2Q==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-22.1.3.tgz",
+      "integrity": "sha512-b4eOsxblp+Ft3KkBtqsZ5Bd8Xbr1m7/yZMHZZ32R2FDNtyceg2XnZsFvdMTxOsbS2upKhYGhqa239ifQw9iITg==",
+      "deprecated": "Angular's Webpack support is deprecated. Use the esbuild and Vite-based \"@angular/build\" package instead.",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5714,14 +5714,14 @@
       "license": "MIT"
     },
     "node_modules/@schematics/angular": {
-      "version": "22.1.2",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.2.tgz",
-      "integrity": "sha512-52udja/QGSNH5geSnL4JWFOEfx8M7tqf7LNXz8byjki4VshVOkKHTawQcL4YbJfo3MfwwXm4AsoadMOk8EST2w==",
+      "version": "22.1.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.1.3.tgz",
+      "integrity": "sha512-5f5f0tKp3d25hjNGkvw2dtGgTN4wxPNhv1AXnhFkh+mLinQK9Qwzr2iEXDDrAuJEkvz1ACHq631IURWph0lqew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.1.2",
-        "@angular-devkit/schematics": "22.1.2",
+        "@angular-devkit/core": "22.1.3",
+        "@angular-devkit/schematics": "22.1.3",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -9601,14 +9601,14 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -9731,13 +9731,13 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -9762,18 +9762,18 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -9781,9 +9781,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12666,9 +12666,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -12686,7 +12686,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12956,9 +12956,9 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15575,9 +15575,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "22.1.2",
-    "@angular/cli": "22.1.2",
+    "@angular-devkit/build-angular": "22.1.3",
+    "@angular/cli": "22.1.3",
     "@angular/compiler-cli": "22.1.0",
     "@capacitor/cli": "8.5.0",
     "@types/jasmine": "6.0.0",


### PR DESCRIPTION
## Summary
Re-ran the dependency/SHA-pin audit against current `master` (which already includes two prior rounds of updates from #26 and #30). This round found and applied:

- `@angular/cli` and `@angular-devkit/build-angular`: `22.1.2` → `22.1.3`
- `azure/login`: `v3.0.0` → `v3.0.1` (SHA-pinned) — patch fix only, no breaking changes
- `github/codeql-action` (`init`/`analyze`/`upload-sarif`): `v4.37.4` → `v4.37.6` (SHA-pinned)
- Refreshed the `node:24-alpine` build-stage digest in the multi-stage `dockerfile`
- Refreshed the `dev-22-bullseye` devcontainer base image digest

Everything else (npm packages, `nginx:alpine`, remaining GitHub Actions) was already at the latest version and already SHA/digest-pinned.

## Test plan
- [x] `npm ci` installs cleanly from the regenerated lockfile
- [x] `npx ng build --configuration production` succeeds
- [x] All edited workflow YAML files parse correctly
- [x] Confirmed no other action/dependency in the repo has a newer release available

🤖 Generated with [Claude Code](https://claude.com/claude-code)